### PR TITLE
Code cell with no output from iopub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,8 @@ dmypy.json
 
 # Yarn cache
 .yarn/
+
+# Miscellaneous
+playground/
+
+.vscode/

--- a/jupyter_rtc_core/app.py
+++ b/jupyter_rtc_core/app.py
@@ -13,9 +13,9 @@ class RtcExtensionApp(ExtensionApp):
         # this can be deleted prior to initial release.
         (r"jupyter-rtc-core/get-example/?", RouteHandler),
         # global awareness websocket
-        (r"api/collaboration/room/JupyterLab:globalAwareness/?", GlobalAwarenessWebsocket),
+        #(r"api/collaboration/room/JupyterLab:globalAwareness/?", GlobalAwarenessWebsocket),
         # ydoc websocket
-        (r"api/collaboration/room/(.*)", YRoomWebsocket)
+        #(r"api/collaboration/room/(.*)", YRoomWebsocket)
     ]
 
     def initialize(self):

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,10 @@ import {
 } from '@jupyterlab/application';
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
-
+import { IEditorServices } from '@jupyterlab/codeeditor';
 import { requestAPI } from './handler';
+import { NotebookPanel } from '@jupyterlab/notebook';
+import { YNotebookContentFactory } from './notebook';
 
 /**
  * Initialization data for the @jupyter/rtc-core extension.
@@ -41,4 +43,24 @@ const plugin: JupyterFrontEndPlugin<void> = {
   }
 };
 
-export default plugin;
+/**
+ * The notebook cell factory provider.
+ */
+const factory: JupyterFrontEndPlugin<NotebookPanel.IContentFactory> = {
+  id: '@jupyter-rtc-core/notebook-extension:factory',
+  description: 'Provides the notebook cell factory.',
+  provides: NotebookPanel.IContentFactory,
+  requires: [IEditorServices],
+  autoStart: true,
+  activate: (app: JupyterFrontEnd, editorServices: IEditorServices) => {
+    const editorFactory = editorServices.factoryService.newInlineEditor;
+    return new YNotebookContentFactory({ editorFactory });
+  }
+};
+
+const plugins: JupyterFrontEndPlugin<any>[] = [
+  plugin,
+  factory
+];
+
+export default plugins;

--- a/src/notebook.ts
+++ b/src/notebook.ts
@@ -1,0 +1,22 @@
+import { CodeCell, CodeCellLayout } from '@jupyterlab/cells';
+import { NotebookPanel } from '@jupyterlab/notebook';
+import { KernelMessage } from '@jupyterlab/services'
+
+class YCodeCell extends CodeCell { 
+ /**
+   * Construct a code cell widget.
+   */
+  constructor(options: CodeCell.IOptions) {
+    super({ layout: new CodeCellLayout(), ...options, placeholder: true });
+    this["_output"]["_onIOPub"] = (msg: KernelMessage.IIOPubMessage) => { 
+        const log = { ...msg.content, output_type: msg.header.msg_type };
+        console.log(log)
+    } 
+  }
+}
+
+export class YNotebookContentFactory extends NotebookPanel.ContentFactory  { 
+  createCodeCell(options: CodeCell.IOptions): YCodeCell {
+    return new YCodeCell(options).initializeState()
+  }
+}


### PR DESCRIPTION
Builds on #19, adds a `YCodeCell` that sends IOPub messages to an noop handler,  that will help in hydrating the cell output from ydoc instead of kernel messages.