### PR TITLE
Adding ydoc version message

### DIFF
--- a/jupyter_rtc_core/websockets/yroom_ws.py
+++ b/jupyter_rtc_core/websockets/yroom_ws.py
@@ -67,6 +67,9 @@ class YRoomWebsocket(WebSocketHandler):
         # Add self as a client to the YRoom
         self.client_id = self.yroom.clients.add(self)
 
+        #Tell the room to send the ydoc version
+        self.yroom.send_ydoc_version(self.client_id)
+
 
     def on_message(self, message: bytes):
         # TODO: remove this later


### PR DESCRIPTION
This add a new `YMessageType.YDOC_VERSION` field and wires up `YRoom` to send that to every new client connection. Each `YRoom` has a new `_ydoc_version` that is a UUID that is recreated anytime the ydoc in created. From the docstring:

If the client has a different ydoc version, it should delete its ydoc, create a new one, and save the new ydoc version. The server must send the ydoc version to new clients before the sync1/sync2 handshake, but can also send it at any time. Clients must initiate sync1/sync2 anytime they receive a ydoc version message.