### PR TITLE
[WIP] Fix issues when using RTCore Yroom

### DIFF
--- a/jupyter_rtc_core/kernels/kernel_client.py
+++ b/jupyter_rtc_core/kernels/kernel_client.py
@@ -199,7 +199,7 @@ class DocumentAwareKernelClient(AsyncKernelClient):
             for yroom in self._yrooms:
                 # NOTE: We need to create a real message here.
                 awareness_update_message = b""
-                self.log.debug(f"Update Awareness here: {dmsg}. YRoom: {yroom}")
+                self.log.info(f"Update Awareness here: {dmsg}. YRoom: {yroom}")
                 #self.log.debug(f"Getting YDoc: {await yroom.get_ydoc()}")
                 #yroom.add_message(awareness_update_message)
             

--- a/jupyter_rtc_core/kernels/kernel_manager.py
+++ b/jupyter_rtc_core/kernels/kernel_manager.py
@@ -1,5 +1,6 @@
 import typing
 import asyncio
+from datetime import datetime
 from traitlets import default
 from traitlets import Instance
 from traitlets import Int
@@ -141,6 +142,7 @@ class NextGenKernelManager(AsyncKernelManager):
         self.set_state(LifecycleStates.CONNECTING, ExecutionStates.BUSY)
         # Use the new API for getting a client.
         self.main_client = self.client()
+        self.last_activity = datetime.utcnow()
         # Track execution state by watching all messages that come through
         # the kernel client.
         self.main_client.add_listener(self.execution_state_listener)
@@ -183,6 +185,7 @@ class NextGenKernelManager(AsyncKernelManager):
     def execution_state_listener(self, channel_name: str, msg: list[bytes]):
         """Set the execution state by watching messages returned by the shell channel."""
         # Only continue if we're on the IOPub where the status is published.
+        self.last_activity = datetime.utcnow()
         if channel_name != "iopub":
             return
         

--- a/jupyter_rtc_core/rooms/yroom.py
+++ b/jupyter_rtc_core/rooms/yroom.py
@@ -64,7 +64,7 @@ class YRoom:
         self._client_group = YjsClientGroup(room_id=room_id, log=self.log, loop=self._loop)
         self._ydoc = pycrdt.Doc()
         self._awareness = pycrdt.Awareness(ydoc=self._ydoc)
-        _, file_type, _ = self.room_id.split(":")
+        file_type, _, _ = self.room_id.split(":")
         JupyterYDocClass = cast(
             type[YBaseDoc],
             jupyter_ydoc_classes.get(file_type, jupyter_ydoc_classes["file"])

--- a/jupyter_rtc_core/rooms/yroom_file_api.py
+++ b/jupyter_rtc_core/rooms/yroom_file_api.py
@@ -34,7 +34,7 @@ class YRoomFileAPI:
     # See `filemanager.py` in `jupyter_server` for references on supported file
     # formats & file types.
     room_id: str
-    file_format: Literal["text", "base64"]
+    file_format: Literal["text", "base64", "json"]
     file_type: Literal["file", "notebook"]
     file_id: str
     log: logging.Logger
@@ -173,6 +173,7 @@ class YRoomFileAPI:
             try:
                 assert self.jupyter_ydoc
                 path = self.get_path()
+                self.log.info(f"Saving content for room ID '{self.room_id}'. {path}. {self.file_format} {self.file_type}")
                 content = self.jupyter_ydoc.source
                 file_format = self.file_format
                 file_type = self.file_type if self.file_type in SAVEABLE_FILE_TYPES else "file"


### PR DESCRIPTION
I have been trying to fix issues that I was encountering when I am integrating kernel manager with new YRoom. These are not correct fixes but shared a draft to discuss

* As mentioned above, roomid is not in expected format. YRoom expects it to be of format "room_id := "{file_type}:{file_format}:{file_id}" eg: json:notebeook:d8ae4475-cd89-484a-a044-2f6b56a0bf8b
* kernel manager needs last_activity without which  kernel starts fail. I did not see this before
* After I fix all above, I am running into issue where "TypeError: argument 'chunk': 'NotebookNode' object cannot be converted to 'PyString'"