### PR TITLE
[temp fix] Always delete client YDoc on disconnect

### DIFF
--- a/src/docprovider/ydrive.ts
+++ b/src/docprovider/ydrive.ts
@@ -143,7 +143,6 @@ export class RtcContentProvider
     if (typeof options.format !== 'string') {
       return;
     }
-    
 
     try {
       const provider = new WebSocketProvider({


### PR DESCRIPTION
## Description

- Fixes #39 

`yprovider.ts` deletes the client YDoc & stops retrying the connection only when the WS close code is `1006`. This indicates an unexpected closure (e.g. via `kill -9 <PID>`). However, our backend should close each WebSocket gracefully before exiting; this sends close code `1000`, which gets ignored by `yprovider.ts`. This causes re-connect attempts to fire constantly from outdated clients after the server is restarted.

This PR simply removes the `if (event.code === 1006)` condition and always deletes the client YDoc & stops retrying the connection on disconnect. This fixes #39 and prevents content duplication when an outdated client connects to a new server session.

While this PR does fix the edge cases, it also worsens the experience for users with a flaky internet connection, who now have to refresh the page manually every time they are disconnected. We can improve this in future PRs; I've identified ways to handle client disconnects more gracefully in a new issue: #45.