### PR TITLE
Publish kernel status into notebook's  awareness

### DIFF
--- a/jupyter_rtc_core/kernels/kernel_client.py
+++ b/jupyter_rtc_core/kernels/kernel_client.py
@@ -182,7 +182,7 @@ class DocumentAwareKernelClient(AsyncKernelClient):
         ------- 
         Returns the message if it should be forwarded to listeners. Otherwise,
         returns `None` and keeps (i.e. intercepts) the message from going
-        to listenres.
+        to listeners.
         """
         # NOTE: Here's where we will inject the kernel state
         # into the awareness of a document.
@@ -200,7 +200,7 @@ class DocumentAwareKernelClient(AsyncKernelClient):
                 update_document_message = b""
                 # yroom.add_message(update_document_message)
 
-            # TODO: returning message temporarily to not break UI
+        # TODO: returning message temporarily to not break UI
         # If the message isn't handled above, return it and it will
         # be forwarded to all listeners
         return msg

--- a/jupyter_rtc_core/kernels/kernel_manager.py
+++ b/jupyter_rtc_core/kernels/kernel_manager.py
@@ -107,7 +107,6 @@ class NextGenKernelManager(AsyncKernelManager):
             
         if broadcast:
             # Broadcast this state change to all listeners
-            # Turn off state broadcasting temporarily to avoid
             self._state_observers = None
             self.broadcast_state()
 
@@ -202,7 +201,6 @@ class NextGenKernelManager(AsyncKernelManager):
                 if parent_channel and parent_channel == "shell":
                     # Don't broadcast, since this message is already going out.
                     self.set_state(LifecycleStates.CONNECTED, ExecutionStates(execution_state), broadcast=False)
-            self.log.debug(f"Execution state changed to {execution_state}")
 
             kernel_status = {
                 "execution_state": self.execution_state,

--- a/jupyter_rtc_core/session_manager.py
+++ b/jupyter_rtc_core/session_manager.py
@@ -8,7 +8,7 @@ from jupyter_rtc_core.kernels.kernel_client import DocumentAwareKernelClient
 
 
 class YDocSessionManager(SessionManager): 
-    """A Jupyter Server Session Manager that's connects YDocuments
+    """A Jupyter Server Session Manager that connects YDocuments
     to Kernel Clients.
     """
     


### PR DESCRIPTION
a) Writes both kernel execution status and lifecycle status into notebooks awareness 

b) addressed some comments from https://github.com/ellisonbg/jupyter-rtc-core/pull/28


Tested through logs. Could not verify on browser