### PR TITLE
Fix extension when used with custom `root_dir`

### DIFF
--- a/jupyter_server_documents/rooms/yroom_file_api.py
+++ b/jupyter_server_documents/rooms/yroom_file_api.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from jupyter_ydoc.ybasedoc import YBaseDoc
 from jupyter_server.utils import ensure_async
 import logging
-import os
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Literal


### PR DESCRIPTION
## Description

Fixes the extension when used with a custom `root_dir`.

This PR works by directly returning the path returned by the `ArbitraryFileIdManager`. This file ID manager already returns paths that are relative to `root_dir`.

I had thought the file ID manager returned absolute paths, so I added a `os.path.relpath()` call to convert the returned path to a relative path. Ironically, this introduced a bug instead of preventing one. If `os.path.relpath()` is called like this:

```py
os.path.relpath("untitled.txt", "/home/jovyan/playground")

# where pwd := "/home/jovyan", but
# ServerApp.root_dir := "/home/jovyan/playground"
```

This actually returns `"../untitled.txt"`, since the first argument is first coerced to an absolute path, using `pwd` instead of `ServerApp.root_dir`. 😵 

## Demo video


https://github.com/user-attachments/assets/1cc7e673-1571-4eb6-94e6-2dd5766dfab6


### Possible JupyterLab issue?

The terminal doesn't seem to be started from `ServerApp.root_dir`. This is from the same server session as the previous demo video, so the terminal should open under `playground/`, not `jupyter-server-documents/`.


https://github.com/user-attachments/assets/31ee6f2e-9184-4b0e-a2be-b54cef0f3492


