### PR TITLE
Handle clear output msg

### DIFF
--- a/jupyter_server_documents/kernels/kernel_client.py
+++ b/jupyter_server_documents/kernels/kernel_client.py
@@ -110,7 +110,7 @@ class DocumentAwareKernelClient(AsyncKernelClient):
         if cell_id:
             existing = self.message_cache.get(cell_id=cell_id)
             if existing and existing['msg_id'] != msg_id:
-                self.output_processor.clear_cell_outputs(cell_id)
+                asyncio.create_task(self.output_processor.clear_cell_outputs(cell_id))
         
         self.message_cache.add({
             "msg_id": msg_id,


### PR DESCRIPTION
Fixes #95 

**Sample code to test**:

```python
%pip install -q ipywidgets
```
```python
from ipywidgets import Output
from IPython.display import display

out = Output()
display(out)
```

```python
import time

with out:
    print("Hello!")

time.sleep(2)
out.clear_output(wait=True) # default is wait=False, which should clear the output immediately

time.sleep(2)
with out:
  print("Hello again!")
```