### PR TITLE
Disable save commands due to autosaving to avoid user confusion

### DIFF
--- a/src/disablesave.ts
+++ b/src/disablesave.ts
@@ -1,4 +1,7 @@
-import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
 import { Notification } from '@jupyterlab/apputils';
 
 const SAVE_MESSAGE = 'Autosaving is enabled, manual saves are not needed';
@@ -21,10 +24,10 @@ const NOTIFICATION_INTERVAL = 20;
  */
 export const disableSavePlugin: JupyterFrontEndPlugin<void> = {
   id: 'disable-save:plugin',
-  description: 'Disables save commands and removes their keyboard shortcuts since documents are autosaved',
+  description:
+    'Disables save commands and removes their keyboard shortcuts since documents are autosaved',
   autoStart: true,
   activate: (app: JupyterFrontEnd): void => {
-
     let saveNotifiedCount = 0;
     let saveAsNotifiedCount = 0;
     let saveAllNotifiedCount = 0;
@@ -33,7 +36,6 @@ export const disableSavePlugin: JupyterFrontEndPlugin<void> = {
      * Override save commands and remove keyboard shortcuts after app is fully loaded
      */
     app.restored.then(() => {
-      
       // Helper function to remove existing command and add new one
       const overrideCommand = (commandId: string, options: any) => {
         if (app.commands.hasCommand(commandId)) {
@@ -47,14 +49,10 @@ export const disableSavePlugin: JupyterFrontEndPlugin<void> = {
       };
 
       const notify = () => {
-        Notification.emit(
-          SAVE_MESSAGE,
-          'info',
-          {
-            autoClose: 2000
-          }
-        )
-      }
+        Notification.emit(SAVE_MESSAGE, 'info', {
+          autoClose: 2000
+        });
+      };
 
       // Override main save command (Ctrl/Cmd+S)
       overrideCommand(SAVE_COMMANDS.save, {
@@ -87,7 +85,7 @@ export const disableSavePlugin: JupyterFrontEndPlugin<void> = {
       // Override save-all command
       overrideCommand(SAVE_COMMANDS.saveAll, {
         label: 'Save All (Autosaving)',
-          caption: SAVE_MESSAGE,
+        caption: SAVE_MESSAGE,
         isEnabled: () => true,
         execute: () => {
           if (saveAllNotifiedCount % NOTIFICATION_INTERVAL === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import {
   IKernelStatusModel,
   ISessionContext,
   ISessionContextDialogs,
-  SessionContextDialogs,
+  SessionContextDialogs
 } from '@jupyterlab/apputils';
 import { KeyboardEvent } from 'react';
 import { IToolbarWidgetRegistry } from '@jupyterlab/apputils';
@@ -304,7 +304,6 @@ export const backupCellExecutorPlugin: JupyterFrontEndPlugin<INotebookCellExecut
       return Object.freeze({ runCell });
     }
   };
-
 
 const plugins: JupyterFrontEndPlugin<unknown>[] = [
   rtcContentProvider,


### PR DESCRIPTION
This commit disables JupyterLab's manual save commands since documents are now autosaved. The implementation:

- Overrides four save-related commands: save, save-as, save-all, and toggle-autosave
- Removes keyboard shortcuts: Cmd/Ctrl+S and Cmd/Ctrl+Shift+S no longer trigger save operations
- Provides user feedback: Menu items show "(Autosaving)" labels and tooltips explaining save operations are disabled
- Maintains UX consistency: Commands remain visible but execute as no-ops instead of being completely hidden

The plugin activates after app restoration to ensure proper command registry manipulation using JupyterLab's private API.