### PR TITLE
Fix typo in `YRoom`

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -827,7 +827,7 @@ class YRoom(LoggingConfigurable):
                 self._message_queue.get_nowait()
                 self._message_queue.task_done()
             else:
-                client_id, message = self._message.queue.get_nowait()
+                client_id, message = self._message_queue.get_nowait()
                 self.handle_message(client_id, message)
         
         # Stop the `_process_message_queue` task by enqueueing `None`


### PR DESCRIPTION
@fperez Thanks for catching this embarassing typo. Fixing the CI will prevent this type of issue from happening again in the future. 😅