### PR TITLE
Delete outputs on disk if outputs have been cleared

### DIFF
--- a/jupyter_server_documents/outputs/manager.py
+++ b/jupyter_server_documents/outputs/manager.py
@@ -302,7 +302,7 @@ class OutputsManager(LoggingConfigurable):
             cell['outputs'] = processed_outputs
         return nb
 
-    def process_saving_notebook(self, nb: dict) -> dict:
+    def process_saving_notebook(self, nb: dict, file_id: str) -> dict:
         """Process a notebook before saving to disk.
 
         This method is called when the yroom_file_api saves notebooks.
@@ -311,6 +311,7 @@ class OutputsManager(LoggingConfigurable):
         
         Args:
             nb (dict): The notebook dict
+            file_id (str): The file identifier
             
         Returns:
             dict: The modified file data with placeholder_outputs set to True
@@ -326,6 +327,12 @@ class OutputsManager(LoggingConfigurable):
         # Clear outputs for all code cells, as they are saved to disk
         for cell in nb.get('cells', []):
             if cell.get('cell_type') == 'code':
+                # If outputs is already an empty list, call clear for this cell
+                if cell.get('outputs') == []:
+                    cell_id = cell.get('id')
+                    if cell_id:
+                        self.clear(file_id, cell_id)
+                
                 cell['outputs'] = []
         
         return nb

--- a/jupyter_server_documents/rooms/yroom_file_api.py
+++ b/jupyter_server_documents/rooms/yroom_file_api.py
@@ -376,7 +376,7 @@ class YRoomFileAPI(LoggingConfigurable):
             self._save_scheduled = False
 
             if self.file_type == "notebook":
-                content = self.outputs_manager.process_saving_notebook(content)
+                content = self.outputs_manager.process_saving_notebook(content, self.file_id)
 
             # Save the YDoc via the ContentsManager
             async with self._content_lock:


### PR DESCRIPTION
Summary

• Delete output files from disk when notebook cell outputs are cleared in memory
• Pass file_id to process_saving_notebook to enable proper cleanup

  Changes

- Modified process_saving_notebook method in OutputsManager to accept file_id parameter
- Added logic to call clear() method when cell outputs are already empty, ensuring disk cleanup
- Updated YRoomFileAPI to pass file_id when processing notebooks for saving

This ensures that when outputs are cleared in the notebook editor, the corresponding output files are also removed from disk, preventing orphaned files and maintaining consistency between memory and disk state.

This is the first part of fixing #134