### PR TITLE
Loosen cell ID regex to match `nbformat` spec

### DIFF
--- a/jupyter_server_documents/outputs/handlers.py
+++ b/jupyter_server_documents/outputs/handlers.py
@@ -67,11 +67,9 @@ class StreamAPIHandler(APIHandler):
 # URL to handler mappings
 # -----------------------------------------------------------------------------
 
-# Strict UUID regex (matches standard 8-4-4-4-12 UUIDs)
-_uuid_regex = r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
-
-_file_id_regex = rf"(?P<file_id>{_uuid_regex})"
-_cell_id_regex = rf"(?P<cell_id>{_uuid_regex})"
+_file_id_regex = r"(?P<file_id>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})"
+# In nbformat, cell_ids follow this format, compatible with uuid4
+_cell_id_regex = rf"(?P<cell_id>[a-zA-Z0-9_-]+)"
 
 # non-negative integers
 _output_index_regex = r"(?P<output_index>0|[1-9]\d*)"
@@ -80,4 +78,3 @@ outputs_handlers = [
     (rf"/api/outputs/{_file_id_regex}/{_cell_id_regex}(?:/{_output_index_regex}.output)?", OutputsAPIHandler),
     (rf"/api/outputs/{_file_id_regex}/{_cell_id_regex}/stream", StreamAPIHandler),
 ]
-


### PR DESCRIPTION
## Summary
- Fixes #137 
- Fix cell ID regex pattern to properly handle nbformat cell IDs with alphanumeric characters, underscores, and hyphens
- Ensure all notebook cells have IDs by upgrading notebooks to nbformat 4.5+ and generating IDs for cells that lack them
- Improve regex pattern specificity for file IDs (inline UUID pattern) and cell IDs (nbformat-compatible pattern)

## Changes
- Updated cell ID regex from strict UUID pattern to `[a-zA-Z0-9_-]+` to match nbformat specification
- Added automatic notebook upgrade to nbformat 4.5+ to ensure cell IDs are available
- Generate UUIDs for cells missing IDs in both read and write operations
- Simplified regex patterns by inlining UUID pattern for file IDs

## Test plan
- [ ] Test API endpoints with various cell ID formats (UUID and alphanumeric)
- [ ] Verify notebooks without cell IDs get properly upgraded and assigned IDs
- [ ] Confirm outputs are correctly saved and retrieved with new cell ID handling

🤖 Generated with [Claude Code](https://claude.ai/code)