### PR TITLE
Fix kernel restart

### DIFF
--- a/jupyter_server_documents/kernels/kernel_client.py
+++ b/jupyter_server_documents/kernels/kernel_client.py
@@ -80,7 +80,7 @@ class DocumentAwareKernelClient(AsyncKernelClient):
         """
         # If the listening task isn't defined yet
         # do nothing.
-        if not self._listening_task:
+        if not hasattr(self, '_listening_task') or not self._listening_task:
             return
 
         # Attempt to cancel the task.
@@ -93,6 +93,9 @@ class DocumentAwareKernelClient(AsyncKernelClient):
         # Log any exceptions that were raised.
         except Exception as err:
             self.log.error(err)
+        finally:
+            # Clear the task reference
+            self._listening_task = None
 
     _listening_task: t.Optional[t.Awaitable] = Any(allow_none=True)
 

--- a/jupyter_server_documents/kernels/kernel_manager.py
+++ b/jupyter_server_documents/kernels/kernel_manager.py
@@ -127,8 +127,9 @@ class NextGenKernelManager(AsyncKernelManager):
             await asyncio.sleep(0.1)
         
     async def disconnect(self):
-        await self.main_client.stop_listening()
-        self.main_client.stop_channels()
+        if self.main_client:
+            await self.main_client.stop_listening()
+            self.main_client.stop_channels()
 
     async def broadcast_state(self):
         """Broadcast state to all listeners"""

--- a/jupyter_server_documents/kernels/multi_kernel_manager.py
+++ b/jupyter_server_documents/kernels/multi_kernel_manager.py
@@ -8,3 +8,10 @@ class NextGenMappingKernelManager(AsyncMappingKernelManager):
     
     def stop_buffering(self, kernel_id):
         pass
+
+    # NOTE: Since we disable watching activity and buffering here, 
+    # this method needs to be forked and remove code related to these things. 
+    async def restart_kernel(self, kernel_id, now=False):
+        """Restart a kernel by kernel_id"""
+        self._check_kernel_id(kernel_id)
+        await self.pinned_superclass._async_restart_kernel(self, kernel_id, now=now)


### PR DESCRIPTION
Fixes #130 

The following error was raised "AttributeError: Socket has no such option: ON_RECV" errors during kernel restart operations. 

 ## Changes

  Kernel Client (kernel_client.py)

  - Enhanced stop_listening() method: Added proper attribute checking with hasattr() to prevent AttributeError when
   _listening_task doesn't exist
  - Added cleanup in finally block: Ensures _listening_task is properly reset to None after cancellation to prevent
   stale references

  Kernel Manager (kernel_manager.py)

  - Improved disconnect() method: Added null check for main_client before attempting to stop listening and
  channels, preventing errors when client is already disconnected

  Multi-Kernel Manager (multi_kernel_manager.py)

  - Added restart_kernel() method: Implemented proper kernel restart that bypasses problematic activity watching
  and buffering, calling the pinned superclass method directly to avoid ZMQ socket issues

##  Problem Solved

  The original error occurred because jupyter_server's _async_restart_kernel method was trying to use outdated ZMQ
  socket options. This fix works around the issue by:
  1. Properly handling missing attributes during client cleanup
  2. Adding safety checks for null clients during disconnection
  3. Implementing a clean restart path that avoids the problematic ZMQ code