### PR TITLE
Increase stream limit to 200

### DIFF
--- a/jupyter_server_documents/outputs/manager.py
+++ b/jupyter_server_documents/outputs/manager.py
@@ -20,7 +20,7 @@ class OutputsManager(LoggingConfigurable):
     _stream_count = Dict(default_value={})
 
     outputs_path = Instance(PurePath, help="The local runtime dir")
-    stream_limit = Int(default_value=10, config=True, allow_none=True)
+    stream_limit = Int(default_value=200, config=True, allow_none=True)
 
     @default("outputs_path")
     def _default_outputs_path(self):


### PR DESCRIPTION
## Summary
Increase the default stream limit from 10 to 200 in the OutputsManager.

This change increases the `stream_limit` default value from 10 to 200 in `jupyter_server_documents/outputs/manager.py:23`, allowing for better handling of larger output streams.

## Test plan
- [ ] Verify the new default value is applied correctly
- [ ] Test with larger output streams to ensure performance remains acceptable

🤖 Generated with [Claude Code](https://claude.ai/code)