### PR TITLE
Fixes server error when deleted rooms are saved at shutdown

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -866,6 +866,9 @@ class YRoom(LoggingConfigurable):
         IMPORTANT: If the server is shutting down, the YRoomManager should call
         `await room.until_saved`. See `until_saved` documentation for more info.
         """
+        if self._stopped:
+            return
+
         self.log.info(f"Stopping YRoom '{self.room_id}'.")
 
         # Disconnect all clients with the given close code


### PR DESCRIPTION
Fixes an error thrown on server for saving room files at shutdown that have been deleted.

## Steps to verify the fix
1. Open a notebook in main area
2. Delete the notebook file in lab
3. Shutdown lab
4. Following error is not thrown with the fixed code:
    ```
    [E 2025-11-13 21:07:16.427 ServerDocsApp] An exception occurred when saving JupyterYDoc.
    [E 2025-11-13 21:07:16.427 ServerDocsApp] 'NoneType' object has no attribute 'strip'
        Traceback (most recent call last):
          File "/Users/pijain/projects/jupyter-server-documents/jupyter_server_documents/rooms/yroom_file_api.py", line 538, in save
            file_data = await ensure_async(self.contents_manager.save(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            ...<6 lines>...
            ))
            ^^
          File "/Users/pijain/miniforge3/envs/serverdocs/lib/python3.13/site-packages/jupyter_core/utils/__init__.py", line 214, in ensure_async
            result = await obj
                     ^^^^^^^^^
          File "/Users/pijain/miniforge3/envs/serverdocs/lib/python3.13/site-packages/jupyter_server/services/contents/largefilemanager.py", line 133, in save
            return await super().save(model, path)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/Users/pijain/miniforge3/envs/serverdocs/lib/python3.13/site-packages/jupyter_server/services/contents/filemanager.py", line 948, in save
            path = path.strip("/")
                   ^^^^^^^^^^
        AttributeError: 'NoneType' object has no attribute 'strip'
    ```

