### PR TITLE
Disable OOB change notification

### DIFF
--- a/src/docprovider/yprovider.ts
+++ b/src/docprovider/yprovider.ts
@@ -269,18 +269,6 @@ export class WebSocketProvider implements IDocumentProvider {
 
     // Re-connect
     this.reconnect();
-
-    // Emit notification if document is open & visible to the user (i.e. the tab
-    // exists & the content of that tab is being shown)
-    const docWidget = this.parentDocumentWidget;
-    if (docWidget && docWidget.isVisible) {
-      Notification.info(
-        `The file '${this._path}' was modified on disk. The document tab has been reset.`,
-        {
-          autoClose: 10000
-        }
-      );
-    }
   }
 
   /**


### PR DESCRIPTION
## Description

This PR disables the OOB change notification when a file was modified directly on disk.

Users have reported in the public Jupyter AI calls that this notification is unnecessary. JSD handles this case well enough to the point where it is nearly indistinguishable from another connected user making edits to the file. Furthermore, when AI agents stream output to files opened by the user, a flood of notifications is produced. This PR fixes these UX issues by disabling the OOB change notification.

After this PR is merged, it would be good to publish the JSD v0.1.0 release. cc @ellisonbg

## Demo


https://github.com/user-attachments/assets/f5dd36b5-b1dc-4e93-86d8-107af09b8ec4

