### PR TITLE
Fixes duplicate cells on OOB changes

### DIFF
--- a/src/notebook-factory/notebook.ts
+++ b/src/notebook-factory/notebook.ts
@@ -50,8 +50,15 @@ export class ResettableNotebook extends Notebook {
       return;
     }
 
-    // Refresh the UI by emitting to the `modelContentChanged` signal
-    this.onModelContentChanged(this.model);
+    // Force a complete rebuild by setting model to null and back.
+    // This works around a JupyterLab bug in v4.5.3+ (PR #18359) where
+    // _updateDataWindowedListIndex updates ALL cell indices from start
+    // without an upper bound, causing cell duplication during OOB changes.
+    // By setting model to null first, we ensure cellsArray is cleared
+    // before repopulating, preventing the duplicate index updates.
+    const savedModel = this.model;
+    super.model = null;
+    super.model = savedModel;
   }
 
   _resetSignalSlot: () => void;


### PR DESCRIPTION
https://github.com/jupyterlab/jupyterlab/pull/18359 introduced a change that is creating duplicate cells when out of band changes are submitted. The fix here forces reset of the model to ensure cells are cleared before repopulating.

**Note**: We can explore a fix inside Jupyter Lab to correct the behavior that PR introduced by removing the end boundary check for deferred rendering, but it's likely to take longer to verify, merge and release. This could be a temp fix until we explore in that direction.