### PR TITLE
Lower WS ping interval to 25 seconds

### DIFF
--- a/jupyter_server_documents/app.py
+++ b/jupyter_server_documents/app.py
@@ -82,6 +82,8 @@ class ServerDocsApp(ExtensionApp):
     def _link_jupyter_server_extension(self, server_app):
         """Setup custom config needed by this extension."""
         c = Config()
+        c.ServerApp.websocket_ping_interval = 25
+        c.ServerApp.websocket_ping_timeout = 10
         c.ServerApp.kernel_websocket_connection_class = "jupyter_server_documents.kernels.websocket_connection.NextGenKernelWebsocketConnection"
         c.ServerApp.kernel_manager_class = "jupyter_server_documents.kernels.multi_kernel_manager.NextGenMappingKernelManager"
         c.MultiKernelManager.kernel_manager_class = "jupyter_server_documents.kernels.kernel_manager.NextGenKernelManager"


### PR DESCRIPTION
Sets `websocket_ping_interval=25` and `websocket_ping_timeout=10` (in seconds) in `_link_jupyter_server_extension`.

Previously these values were configured as 30000/90000, which Tornado interprets as ~8.3/~25 hours since it expects seconds. This effectively disabled the ping/pong keepalive, causing WebSocket 1006 disconnections behind reverse proxies and load balancers (Nginx 60s default timeout, AWS ALB 60s default idle timeout).

A 25-second ping interval keeps connections alive through proxies with 30–60 second idle timeouts, and the 10-second pong timeout allows prompt detection of dead connections.

Fixes #199