### PR TITLE
Add ping/pong keepalive to YRoomWebsocket

### DIFF
--- a/jupyter_server_documents/tests/test_yroom_ws.py
+++ b/jupyter_server_documents/tests/test_yroom_ws.py
@@ -26,6 +26,6 @@ class TestYRoomWebsocket:
         assert isinstance(handler.ping_timeout, (int, float))
         assert 0 < handler.ping_timeout < 30
 
-    def test_ping_timeout_less_than_interval(self, mock_server_docs_app):
+    def test_ping_timeout_not_greater_than_ping_interval(self, mock_server_docs_app):
         handler = self._make_handler(mock_server_docs_app)
-        assert handler.ping_timeout < handler.ping_interval
+        assert handler.ping_timeout <= handler.ping_interval

--- a/jupyter_server_documents/tests/test_yroom_ws.py
+++ b/jupyter_server_documents/tests/test_yroom_ws.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+
+from tornado.httputil import HTTPServerRequest
+
+from jupyter_server_documents.websockets import YRoomWebsocket
+
+
+class TestYRoomWebsocket:
+    def _make_handler(self, mock_server_docs_app):
+        app = mock_server_docs_app.serverapp.web_app
+        conn = MagicMock()
+        request = HTTPServerRequest(
+            method="GET",
+            uri="/api/collaboration/room/test",
+            connection=conn,
+        )
+        return YRoomWebsocket(app, request)
+
+    def test_ping_interval_is_set(self, mock_server_docs_app):
+        handler = self._make_handler(mock_server_docs_app)
+        assert isinstance(handler.ping_interval, (int, float))
+        assert 0 < handler.ping_interval < 30
+
+    def test_ping_timeout_is_set(self, mock_server_docs_app):
+        handler = self._make_handler(mock_server_docs_app)
+        assert isinstance(handler.ping_timeout, (int, float))
+        assert 0 < handler.ping_timeout < 30
+
+    def test_ping_timeout_less_than_interval(self, mock_server_docs_app):
+        handler = self._make_handler(mock_server_docs_app)
+        assert handler.ping_timeout < handler.ping_interval

--- a/jupyter_server_documents/websockets/yroom_ws.py
+++ b/jupyter_server_documents/websockets/yroom_ws.py
@@ -19,6 +19,13 @@ class YRoomWebsocket(WebSocketHandler):
     # `ExtensionApp` to log messages w/ "ServerDocsApp" prefix
     log = logging.Logger("TEMP")
 
+    @property
+    def ping_interval(self) -> float:
+        return 25
+
+    @property
+    def ping_timeout(self) -> float:
+        return 10
 
     @property
     def yroom_manager(self) -> YRoomManager:

--- a/jupyter_server_documents/websockets/yroom_ws.py
+++ b/jupyter_server_documents/websockets/yroom_ws.py
@@ -21,11 +21,11 @@ class YRoomWebsocket(WebSocketHandler):
 
     @property
     def ping_interval(self) -> float:
-        return 25
+        return self.settings.get("ws_ping_interval", 25000) / 1000
 
     @property
     def ping_timeout(self) -> float:
-        return 10
+        return self.settings.get("ws_ping_timeout", 25000) / 1000
 
     @property
     def yroom_manager(self) -> YRoomManager:


### PR DESCRIPTION
- Fixes #199

Overrides `ping_interval` (25s) and `ping_timeout` (10s) on `YRoomWebsocket` to enable Tornado's native WebSocket ping/pong keepalive.

Without this, the collaboration WebSocket has no keepalive at all — Tornado's `WebSocketHandler.ping_interval` defaults to `None` (disabled), and Jupyter Server's `ServerApp.websocket_ping_interval` defaults to `0`. Idle connections are killed by reverse proxies and load balancers with close code 1006.
