### PR TITLE
Fix content duplication on reconnection

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -238,7 +238,9 @@ class YRoom(LoggingConfigurable):
         self._on_stop_callbacks: list[Callable[[], Any]] = []
         self._stopped = False
         self._updated = False
-        self._pending_source_restore: dict[str, str] = {}
+        self._pending_ss2_future: asyncio.Future[bytes] | None = None
+        self._pending_ss2_client_id: str | None = None
+        self._suppress_broadcasts = False
         self._save_task = None
         self._last_activity = time.monotonic()
         self.show_gc_debug = self.parent.show_gc_debug
@@ -519,7 +521,21 @@ class YRoom(LoggingConfigurable):
         """
         Adds new message to the message queue. Items placed in the message queue
         are handled one-at-a-time.
+
+        If handle_sync_step1 is awaiting an SS2 reply from a client, the reply
+        bypasses the queue and resolves the pending future directly.
         """
+        if (
+            self._pending_ss2_future is not None
+            and not self._pending_ss2_future.done()
+            and client_id == self._pending_ss2_client_id
+            and len(message) >= 2
+            and message[0] == YMessageType.SYNC
+            and message[1] == YSyncMessageSubtype.SYNC_STEP2
+        ):
+            self._pending_ss2_future.set_result(message)
+            return
+
         self._message_queue.put_nowait((client_id, message))
     
 
@@ -549,7 +565,7 @@ class YRoom(LoggingConfigurable):
 
             # Otherwise, process & handle the new message
             client_id, message = queue_item
-            self.handle_message(client_id, message)
+            await self.handle_message(client_id, message)
             
             # Finally, inform the asyncio Queue that the task was complete
             # This is required for `self._message_queue.join()` to unblock once
@@ -561,16 +577,21 @@ class YRoom(LoggingConfigurable):
             f"for YRoom '{self.room_id}'."
         )
     
-    def handle_message(self, client_id: str, message: bytes) -> None:
+    async def handle_message(self, client_id: str, message: bytes) -> None:
         """
         Handles all messages from every client received in the message queue by
         calling the appropriate handler based on the message type. This method
         routes the message to one of the following methods:
 
-        - `handle_sync_step1()`
-        - `handle_sync_step2()`
-        - `handle_sync_update()`
-        - `handle_awareness_update()`
+        - `await handle_sync()`: performs a sync handshake initiated by a
+        client's SS1 message and returns once the handshake is complete. This
+        blocks handling of other messages until the sync handshake is complete.
+
+        - `handle_sync_update()`: immediately applies a document update from a
+        synced client.
+
+        - `handle_awareness_update()`: immediately applies an awareness update
+        from a synced client.
         """
 
         # Determine message type & subtype from header
@@ -603,12 +624,12 @@ class YRoom(LoggingConfigurable):
             self.log.debug(f"Handled AwarenessUpdate from '{client_id}' for room '{self.room_id}'.")
         # Handle Sync messages
         elif sync_message_subtype == YSyncMessageSubtype.SYNC_STEP1:
-            self.handle_sync_step1(client_id, message)
+            await self.handle_sync(client_id, message)
         elif sync_message_subtype == YSyncMessageSubtype.SYNC_STEP2:
-            self.handle_sync_step2(client_id, message)
+            self.log.warning("Received SS2 message in message loop, this should never happen.")
+            return
         elif sync_message_subtype == YSyncMessageSubtype.SYNC_UPDATE:
             self.handle_sync_update(client_id, message)
-
 
     @staticmethod
     def _decode_state_vector(sv: bytes) -> dict[int, int]:
@@ -627,109 +648,137 @@ class YRoom(LoggingConfigurable):
         server_sv = self._decode_state_vector(self._ydoc.get_state())
         return bool(set(client_sv) - set(server_sv))
 
+    async def handle_sync(self, client_id: str, ss1_message: bytes) -> None:
+        """
+        Handles the bidirectional sync handshake initiated upon receiving a
+        SyncStep1 message from a new client. Specifically, this method:
+
+        1. Sends a SyncStep2 reply providing server side updates,
+        2. Sends a SyncStep1 message requesting client side updates,
+        3. Awaits the client's SyncStep2 reply (up to 5s timeout),
+        4. Applies the client's SyncStep2 reply.
+
+        If the client has divergent history (stale client from a previous
+        session), the server clears the YDoc source before the handshake,
+        suppresses broadcasts and saves, then restores the source after the
+        handshake completes. This prevents content duplication caused by merging
+        two YDocs with the same content but different CRDT histories.
+        """
+        # Mark client as desynced
+        self.clients.mark_desynced(client_id)
+
+        # Check if client has divergent history
+        ss1_payload = ss1_message[1:]
+        divergent = self._has_divergent_history(ss1_payload)
+
+        # If divergent, clear the YDoc source and suppress broadcasts and file
+        # saves until the sync handshake completes.
+        saved_source = None
+        if divergent and self._jupyter_ydoc is not None:
+            self.log.warning(
+                "Client '%s' has divergent history. Clearing YDoc source before handshake.",
+                client_id,
+            )
+            saved_source = self._jupyter_ydoc.source
+            if self.file_api is not None:
+                self.file_api._reloading_content = True
+            self._suppress_broadcasts = True
+            self._jupyter_ydoc.source = ""
+
+        # Initialize future that resolves when an SS2 reply is received.
+        loop = asyncio.get_running_loop()
+        self._pending_ss2_future = loop.create_future()
+        self._pending_ss2_client_id = client_id
+
+        # Core handshake logic.
+        # If handshake fails at any point, cut the WebSocket connection.
+        self.log.info("Initiating handshake with client '%s'.")
+        handshake_success = False
+        try:
+            self.handle_sync_step1(client_id, ss1_message)
+            ss2_message = await asyncio.wait_for(self._pending_ss2_future, timeout=5.0)
+            self.handle_sync_step2(client_id, ss2_message)
+            handshake_success = True
+            self.log.info("Completed handshake with client '%s'.")
+        except asyncio.TimeoutError:
+            self.log.warning(
+                "Timed out waiting for SyncStep2 reply from client '%s'.",
+                client_id,
+            )
+        except Exception:
+            self.log.exception("Exception occurred during sync handshake with new client:")
+
+        # Re-enable broadcasts and file saves and restore the YDoc source
+        # regardless of whether the handshake succeeded.
+        self._suppress_broadcasts = False
+        if self.file_api is not None:
+            self.file_api._reloading_content = False
+        if (divergent or saved_source) and self._jupyter_ydoc is not None:
+            self._jupyter_ydoc.source = saved_source
+            self.log.info("Restored YDoc source.")
+        
+        # Clear instance state
+        self._pending_ss2_future = None
+        self._pending_ss2_client_id = None
+
+        # Mark client as synced if successful, otherwise cut the connection.
+        if handshake_success:
+            self.clients.mark_synced(client_id)
+        else:
+            self.log.error("Disconnecting client '%s' due to failed handshake.", client_id)
+            self.clients.remove(client_id)
+
     def handle_sync_step1(self, client_id: str, message: bytes) -> None:
         """
         Handles SyncStep1 messages from new clients by:
 
-        - Computing a SyncStep2 reply,
-        - Sending the reply to the client over WS, and
+        - Computing and sending a SyncStep2 reply,
         - Sending a new SyncStep1 message immediately after.
 
-        If the client has divergent history (stale client from a previous
-        session), the server clears its source before the handshake and
-        restores it afterwards. This prevents content duplication caused by
-        merging two YDocs with the same content but different CRDT histories.
+        Should re-raise all exceptions so they are caught by `handle_sync()`.
         """
-        # Mark client as desynced
         new_client = self.clients.get(client_id)
-        self.clients.mark_desynced(client_id)
-
         message_payload = message[1:]
-        divergent = self._has_divergent_history(message_payload)
 
-        if divergent and self._jupyter_ydoc is not None:
-            self.log.warning(
-                "Client '%s' has divergent history. Clearing source before handshake.",
-                client_id,
-            )
-            self._pending_source_restore[client_id] = self._jupyter_ydoc.source
-            if self.file_api is not None:
-                self.file_api._reloading_content = True
-            self._jupyter_ydoc.source = ""
-
-        # Compute SyncStep2 reply
+        # Compute and send SyncStep2 reply
         try:
             sync_step2_message = pycrdt.handle_sync_message(message_payload, self._ydoc)
             assert isinstance(sync_step2_message, bytes)
-        except Exception as e:
-            self.log.error(
-                "An exception occurred when computing the SyncStep2 reply "
-                f"to new client '{new_client.id}':"
-            )
-            self.log.exception(e)
-            return
-
-        # Write SyncStep2 reply to the client's WebSocket
-        # Marks client as synced.
-        try:
-            # TODO: remove the assert once websocket is made required
-            assert isinstance(new_client.websocket, WebSocketHandler)
             new_client.websocket.write_message(sync_step2_message, binary=True)
         except Exception as e:
-            self.log.error(
-                "An exception occurred when writing the SyncStep2 reply "
+            self.log.exception(
+                "An exception occurred when computing/sending the SyncStep2 reply "
                 f"to new client '{new_client.id}':"
             )
-            self.log.exception(e)
-            return
+            raise
 
-        self.clients.mark_synced(client_id)
-
-        # Send SyncStep1 message
+        # Send SyncStep1 message to client
         try:
             assert isinstance(new_client.websocket, WebSocketHandler)
             sync_step1_message = pycrdt.create_sync_message(self._ydoc)
             new_client.websocket.write_message(sync_step1_message, binary=True)
         except Exception as e:
-            self.log.error(
+            self.log.exception(
                 "An exception occurred when writing a SyncStep1 message "
                 f"to newly-synced client '{new_client.id}':"
             )
-            self.log.exception(e)
-
+            raise
 
     def handle_sync_step2(self, client_id: str, message: bytes) -> None:
         """
-        Handles SyncStep2 messages from newly-synced clients by applying the
-        SyncStep2 message to YDoc.
+        Applies a SyncStep2 message from a client to the YDoc.
 
-        A SyncUpdate message will automatically be broadcast to all synced
-        clients after this method is called via the `self.write_sync_update()`
-        observer.
+        Should re-raise all exceptions so they are caught by `handle_sync()`.
         """
         try:
             message_payload = message[1:]
             pycrdt.handle_sync_message(message_payload, self._ydoc)
         except Exception as e:
-            self.log.error(
+            self.log.exception(
                 "An exception occurred when applying a SyncStep2 message "
                 f"from client '{client_id}':"
             )
-            self.log.exception(e)
-            return
-
-        # If this client had divergent history, restore the source now that
-        # the bidirectional handshake is complete. Both YDocs share the same
-        # history, so setting source will cleanly delete all stale items and
-        # broadcast the correct content to all clients.
-        saved_source = self._pending_source_restore.pop(client_id, None)
-        if saved_source is not None and self._jupyter_ydoc is not None:
-            try:
-                self._jupyter_ydoc.source = saved_source
-            finally:
-                if self.file_api is not None:
-                    self.file_api._reloading_content = False
-
+            raise
 
     def handle_sync_update(self, client_id: str, message: bytes) -> None:
         """
@@ -780,6 +829,9 @@ class YRoom(LoggingConfigurable):
         The YDoc is saved in the `self._on_jupyter_ydoc_update()` observer.
         """
         self._update_activity("_on_ydoc_update")
+        if self._suppress_broadcasts:
+            # TODO: don't just drop pending updates, queue them!
+            return
         update: bytes = event.update
         message = pycrdt.create_update_message(update)
         self._broadcast_message(message, message_type="SyncUpdate")
@@ -909,8 +961,6 @@ class YRoom(LoggingConfigurable):
 
         for client in clients:
             try:
-                # TODO: remove this assertion once websocket is made required
-                assert isinstance(client.websocket, WebSocketHandler)
                 client.websocket.write_message(message, binary=True)
             except Exception as e:
                 self.log.warning(

--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -649,7 +649,10 @@ class YRoom(LoggingConfigurable):
         session."""
         d = pycrdt.Decoder(message_payload)
         d.read_var_uint()  # skip subtype
-        client_sv = self._decode_state_vector(d.read_message())
+        sv_bytes = d.read_message()
+        if sv_bytes is None:
+            return False
+        client_sv = self._decode_state_vector(sv_bytes)
         if not client_sv:
             return False
         server_sv = self._decode_state_vector(self._ydoc.get_state())
@@ -1100,7 +1103,14 @@ class YRoom(LoggingConfigurable):
                 queue_item = self._message_queue.get_nowait()
                 if queue_item is not None:
                     client_id, message = queue_item
-                    self.handle_message(client_id, message)
+                    # Call sync handlers directly instead of async
+                    # handle_message(). SyncStep1 is skipped because clients
+                    # are already disconnected and a handshake cannot complete.
+                    msg_type = message[0]
+                    if msg_type == YMessageType.SYNC and len(message) >= 2 and message[1] == YSyncMessageSubtype.SYNC_UPDATE:
+                        self.handle_sync_update(client_id, message)
+                    elif msg_type == YMessageType.AWARENESS:
+                        self.handle_awareness_update(client_id, message)
                 self._message_queue.task_done()
         
         # Stop the `_process_message_queue` task by enqueueing `None`

--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -8,7 +8,6 @@ from pycrdt import YMessageType, YSyncMessageType as YSyncMessageSubtype
 from jupyter_server_documents.ydocs import ydocs as jupyter_ydoc_classes
 from jupyter_ydoc.ybasedoc import YBaseDoc
 from jupyter_events import EventLogger
-from tornado.websocket import WebSocketHandler
 from traitlets.config import LoggingConfigurable
 import traitlets
 
@@ -772,7 +771,6 @@ class YRoom(LoggingConfigurable):
 
         # Send SyncStep1 message to client
         try:
-            assert isinstance(new_client.websocket, WebSocketHandler)
             sync_step1_message = pycrdt.create_sync_message(self._ydoc)
             new_client.websocket.write_message(sync_step1_message, binary=True)
         except Exception as e:

--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -238,6 +238,7 @@ class YRoom(LoggingConfigurable):
         self._on_stop_callbacks: list[Callable[[], Any]] = []
         self._stopped = False
         self._updated = False
+        self._pending_source_restore: dict[str, str] = {}
         self._save_task = None
         self._last_activity = time.monotonic()
         self.show_gc_debug = self.parent.show_gc_debug
@@ -609,6 +610,23 @@ class YRoom(LoggingConfigurable):
             self.handle_sync_update(client_id, message)
 
 
+    @staticmethod
+    def _decode_state_vector(sv: bytes) -> dict[int, int]:
+        d = pycrdt.Decoder(sv)
+        return {d.read_var_uint(): d.read_var_uint() for _ in range(d.read_var_uint())}
+
+    def _has_divergent_history(self, message_payload: bytes) -> bool:
+        """Returns True if the client's state vector contains client IDs
+        unknown to the server, indicating a stale client from a previous
+        session."""
+        d = pycrdt.Decoder(message_payload)
+        d.read_var_uint()  # skip subtype
+        client_sv = self._decode_state_vector(d.read_message())
+        if not client_sv:
+            return False
+        server_sv = self._decode_state_vector(self._ydoc.get_state())
+        return bool(set(client_sv) - set(server_sv))
+
     def handle_sync_step1(self, client_id: str, message: bytes) -> None:
         """
         Handles SyncStep1 messages from new clients by:
@@ -616,14 +634,31 @@ class YRoom(LoggingConfigurable):
         - Computing a SyncStep2 reply,
         - Sending the reply to the client over WS, and
         - Sending a new SyncStep1 message immediately after.
+
+        If the client has divergent history (stale client from a previous
+        session), the server clears its source before the handshake and
+        restores it afterwards. This prevents content duplication caused by
+        merging two YDocs with the same content but different CRDT histories.
         """
         # Mark client as desynced
         new_client = self.clients.get(client_id)
         self.clients.mark_desynced(client_id)
 
+        message_payload = message[1:]
+        divergent = self._has_divergent_history(message_payload)
+
+        if divergent and self._jupyter_ydoc is not None:
+            self.log.warning(
+                "Client '%s' has divergent history. Clearing source before handshake.",
+                client_id,
+            )
+            self._pending_source_restore[client_id] = self._jupyter_ydoc.source
+            if self.file_api is not None:
+                self.file_api._reloading_content = True
+            self._jupyter_ydoc.source = ""
+
         # Compute SyncStep2 reply
         try:
-            message_payload = message[1:]
             sync_step2_message = pycrdt.handle_sync_message(message_payload, self._ydoc)
             assert isinstance(sync_step2_message, bytes)
         except Exception as e:
@@ -682,6 +717,18 @@ class YRoom(LoggingConfigurable):
             )
             self.log.exception(e)
             return
+
+        # If this client had divergent history, restore the source now that
+        # the bidirectional handshake is complete. Both YDocs share the same
+        # history, so setting source will cleanly delete all stale items and
+        # broadcast the correct content to all clients.
+        saved_source = self._pending_source_restore.pop(client_id, None)
+        if saved_source is not None and self._jupyter_ydoc is not None:
+            try:
+                self._jupyter_ydoc.source = saved_source
+            finally:
+                if self.file_api is not None:
+                    self.file_api._reloading_content = False
 
 
     def handle_sync_update(self, client_id: str, message: bytes) -> None:

--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -682,8 +682,15 @@ class YRoom(LoggingConfigurable):
             saved_source = self._jupyter_ydoc.source
             if self.file_api is not None:
                 self.file_api._reloading_content = True
-            self._suppress_broadcasts = True
-            self._jupyter_ydoc.source = ""
+            # reset JupyterYDoc source
+            saved_source = self._jupyter_ydoc.source
+            _, file_type, _ = self.room_id.split(":")
+            JupyterYDocClass = cast(
+                type[YBaseDoc],
+                jupyter_ydoc_classes.get(file_type, jupyter_ydoc_classes["file"])
+            )
+            empty_jupyter_ydoc = JupyterYDocClass()
+            self._jupyter_ydoc.source = empty_jupyter_ydoc.source
 
         # Initialize future that resolves when an SS2 reply is received.
         loop = asyncio.get_running_loop()

--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -713,7 +713,6 @@ class YRoom(LoggingConfigurable):
             self.handle_sync_step1(client_id, ss1_message)
             ss2_message = await asyncio.wait_for(self._pending_ss2_future, timeout=5.0)
             self.handle_sync_step2(client_id, ss2_message)
-            self.clients.mark_synced(client_id)
             self.log.info("Completed handshake with client '%s' in room '%s'.", client_id, self.room_id)
         except asyncio.TimeoutError:
             self.log.warning(
@@ -750,6 +749,7 @@ class YRoom(LoggingConfigurable):
         Handles SyncStep1 messages from new clients by:
 
         - Computing and sending a SyncStep2 reply,
+        - Marking the client as synced (ready to receive server updates),
         - Sending a new SyncStep1 message immediately after.
 
         Should re-raise all exceptions so they are caught by `handle_sync()`.
@@ -762,6 +762,10 @@ class YRoom(LoggingConfigurable):
             sync_step2_message = pycrdt.handle_sync_message(message_payload, self._ydoc)
             assert isinstance(sync_step2_message, bytes)
             new_client.websocket.write_message(sync_step2_message, binary=True)
+            # Mark client as synced immediately after sending SS2. This means
+            # that client has latest copy of server's state and is ready to
+            # receive updates to the server.
+            self.clients.mark_synced(client_id)
         except Exception as e:
             self.log.exception(
                 "An exception occurred when computing/sending the SyncStep2 reply "

--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -15,6 +15,7 @@ import traitlets
 from ..websockets import YjsClientGroup
 from .yroom_file_api import YRoomFileAPI
 from .yroom_events_api import YRoomEventsAPI
+from .yroom_update_buffer import YRoomUpdateBuffer
 
 if TYPE_CHECKING:
     import logging
@@ -223,6 +224,11 @@ class YRoom(LoggingConfigurable):
     `YRoomManager.show_gc_debug` trait.
     """
 
+    update_buffer: YRoomUpdateBuffer
+    """
+    Buffer for all SyncUpdate messages. See class docstring for more details.
+    """
+
 
     def __init__(self, *args, **kwargs):
         # Forward all arguments to parent class
@@ -240,7 +246,6 @@ class YRoom(LoggingConfigurable):
         self._updated = False
         self._pending_ss2_future: asyncio.Future[bytes] | None = None
         self._pending_ss2_client_id: str | None = None
-        self._suppress_broadcasts = False
         self._save_task = None
         self._last_activity = time.monotonic()
         self.show_gc_debug = self.parent.show_gc_debug
@@ -250,6 +255,9 @@ class YRoom(LoggingConfigurable):
         self._client_group = ClientGroupClass(room_id=self.room_id, log=self.log)
         self._ydoc = self._init_ydoc()
         self._awareness = self._init_awareness(ydoc=self._ydoc)
+
+        # Initialize YRoomUpdateBuffer
+        self.update_buffer = YRoomUpdateBuffer(parent=self)
 
         # If this room is providing global awareness, set unused optional
         # attributes to `None`.
@@ -671,15 +679,16 @@ class YRoom(LoggingConfigurable):
         ss1_payload = ss1_message[1:]
         divergent = self._has_divergent_history(ss1_payload)
 
-        # If divergent, clear the YDoc source and suppress broadcasts and file
-        # saves until the sync handshake completes.
+        # If divergent, pause update broadcasts and file saves then clear the
+        # YDoc source to prevent content duplication.
         saved_source = None
         if divergent and self._jupyter_ydoc is not None:
             self.log.warning(
-                "Client '%s' has divergent history. Clearing YDoc source before handshake.",
+                "Client '%s' has divergent history in room '%s'. Clearing YDoc source before handshake.",
                 client_id,
+                self.room_id
             )
-            saved_source = self._jupyter_ydoc.source
+            self.update_buffer.pause()
             if self.file_api is not None:
                 self.file_api._reloading_content = True
             # reset JupyterYDoc source
@@ -699,40 +708,42 @@ class YRoom(LoggingConfigurable):
 
         # Core handshake logic.
         # If handshake fails at any point, cut the WebSocket connection.
-        self.log.info("Initiating handshake with client '%s'.")
-        handshake_success = False
+        self.log.info("Initiating handshake with client '%s' in room '%s'.", client_id, self.room_id)
+        handshake_failed = False
         try:
             self.handle_sync_step1(client_id, ss1_message)
             ss2_message = await asyncio.wait_for(self._pending_ss2_future, timeout=5.0)
             self.handle_sync_step2(client_id, ss2_message)
-            handshake_success = True
-            self.log.info("Completed handshake with client '%s'.")
+            self.clients.mark_synced(client_id)
+            self.log.info("Completed handshake with client '%s' in room '%s'.", client_id, self.room_id)
         except asyncio.TimeoutError:
             self.log.warning(
-                "Timed out waiting for SyncStep2 reply from client '%s'.",
+                "Timed out waiting for SyncStep2 reply from client '%s' in room '%s'.",
                 client_id,
+                self.room_id
             )
+            handshake_failed = True
         except Exception:
-            self.log.exception("Exception occurred during sync handshake with new client:")
+            self.log.exception("Exception raised during sync handshake with client '%s' in room '%s':", client_id, self.room_id)
+            handshake_failed = True
 
-        # Re-enable broadcasts and file saves and restore the YDoc source
-        # regardless of whether the handshake succeeded.
-        self._suppress_broadcasts = False
-        if self.file_api is not None:
-            self.file_api._reloading_content = False
-        if (divergent or saved_source) and self._jupyter_ydoc is not None:
+        # Restore the YDoc source, flush all document updates queued in the
+        # update_buffer, and resume saving, regardless of whether the handshake
+        # succeeded.
+        if saved_source is not None and self._jupyter_ydoc is not None:
             self._jupyter_ydoc.source = saved_source
             self.log.info("Restored YDoc source.")
+        self.update_buffer.resume()
+        if self.file_api is not None:
+            self.file_api._reloading_content = False
         
         # Clear instance state
         self._pending_ss2_future = None
         self._pending_ss2_client_id = None
 
-        # Mark client as synced if successful, otherwise cut the connection.
-        if handshake_success:
-            self.clients.mark_synced(client_id)
-        else:
-            self.log.error("Disconnecting client '%s' due to failed handshake.", client_id)
+        # Cut the connection.
+        if handshake_failed:
+            self.log.error("Disconnecting client '%s' due to failed sync handshake in room '%s'.", client_id, self.room_id)
             self.clients.remove(client_id)
 
     def handle_sync_step1(self, client_id: str, message: bytes) -> None:
@@ -836,12 +847,9 @@ class YRoom(LoggingConfigurable):
         The YDoc is saved in the `self._on_jupyter_ydoc_update()` observer.
         """
         self._update_activity("_on_ydoc_update")
-        if self._suppress_broadcasts:
-            # TODO: don't just drop pending updates, queue them!
-            return
         update: bytes = event.update
         message = pycrdt.create_update_message(update)
-        self._broadcast_message(message, message_type="SyncUpdate")
+        self.update_buffer.send_update(message)
 
 
     def add_stop_callback(self, callback: Callable[[], Any]) -> None:

--- a/jupyter_server_documents/rooms/yroom_update_buffer.py
+++ b/jupyter_server_documents/rooms/yroom_update_buffer.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from traitlets.config import LoggingConfigurable
+
+if TYPE_CHECKING:
+    from ..websockets import YjsClientGroup
+
+
+class YRoomUpdateBuffer(LoggingConfigurable):
+    """
+    Broadcasts SyncUpdate messages to connected clients normally, queues them
+    when paused, and flushes queued messages when resumed.
+
+    When a client with divergent history syncs, we clear the YDoc before the
+    handshake and restore it after. Pausing the buffer prevents other clients
+    from seeing a flash of empty content.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._paused = False
+        self._queue: list[bytes] = []
+
+    @property
+    def clients(self) -> YjsClientGroup:
+        return self.parent.clients
+
+    def send_update(self, message: bytes) -> None:
+        """Broadcast a SyncUpdate message to all synced clients, or queue it
+        if paused."""
+        if self._paused:
+            self._queue.append(message)
+            return
+        self._broadcast(message)
+
+    def pause(self) -> None:
+        """Start queuing updates instead of broadcasting them."""
+        self._paused = True
+
+    def resume(self) -> None:
+        """Broadcast all queued updates and unpause."""
+        queued = self._queue
+        self._queue = []
+        self._paused = False
+        for message in queued:
+            self._broadcast(message)
+
+    def _broadcast(self, message: bytes) -> None:
+        """Send a message to all synced clients."""
+        for client in self.clients.get_all():
+            try:
+                client.websocket.write_message(message, binary=True)
+            except Exception as e:
+                self.log.warning(
+                    f"Failed to broadcast SyncUpdate to client '{client.id}': {e}"
+                )

--- a/jupyter_server_documents/rooms/yroom_update_buffer.py
+++ b/jupyter_server_documents/rooms/yroom_update_buffer.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from traitlets.config import LoggingConfigurable
 
 if TYPE_CHECKING:
+    from .yroom import YRoom
     from ..websockets import YjsClientGroup
 
 
@@ -16,6 +17,8 @@ class YRoomUpdateBuffer(LoggingConfigurable):
     handshake and restore it after. Pausing the buffer prevents other clients
     from seeing a flash of empty content.
     """
+
+    parent: YRoom
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jupyter_server_documents/tests/test_yroom_sync.py
+++ b/jupyter_server_documents/tests/test_yroom_sync.py
@@ -1,0 +1,314 @@
+"""
+Integration tests for YRoom sync handshake behavior.
+
+These tests use a FakeWebSocket client that simulates the client side of the
+Yjs sync protocol against a real YRoom instance. They verify:
+
+1. Normal sync handshake completes successfully.
+2. Divergent client detection works correctly.
+3. Divergent client handshake resolves content duplication.
+4. Timeout fires if client never sends SS2.
+5. Update buffer pauses/resumes correctly during divergent handshake.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pycrdt
+from pycrdt import Doc, Text
+from pycrdt import YMessageType, YSyncMessageType as YSyncMessageSubtype
+import pytest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...conftest import MakeYRoom
+    from jupyter_server_documents.rooms.yroom import YRoom
+
+
+class FakeWebSocket:
+    """A fake WebSocket that records messages sent by the server and can
+    replay the client side of the Yjs sync handshake.
+
+    Usage:
+        ws = FakeWebSocket()
+        # optionally pre-populate with divergent content:
+        ws.doc["source"] += "hello world"
+
+        client_id = yroom.clients.add(ws)
+        # server processes SS1 via the message queue or handle_sync()
+        # then inspect ws.messages for what the server sent
+    """
+
+    def __init__(self, doc: Doc | None = None):
+        self.doc = doc or Doc()
+        if "source" not in self.doc:
+            self.doc["source"] = Text()
+        self.messages: list[bytes] = []
+        self.closed = False
+        self.close_code: int | None = None
+        # Required by YjsClientGroup.get() check
+        self.ws_connection = True
+
+    def write_message(self, message: bytes, binary: bool = True) -> None:
+        """Called by the server to send a message to this client."""
+        self.messages.append(message)
+
+    def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.closed = True
+        self.close_code = code
+
+    def build_ss1(self) -> bytes:
+        """Build an SS1 message from this client's YDoc."""
+        return pycrdt.create_sync_message(self.doc)
+
+    def process_server_messages(self) -> bytes | None:
+        """Process all messages from the server (SS2 + SS1) and return the
+        SS2 reply to send back, or None if no SS1 was received."""
+        ss2_reply = None
+        for msg in self.messages:
+            if len(msg) < 2:
+                continue
+            msg_type = msg[0]
+            if msg_type == YMessageType.SYNC:
+                reply = pycrdt.handle_sync_message(msg[1:], self.doc)
+                if reply is not None:
+                    # reply is an SS2 response to the server's SS1
+                    ss2_reply = reply
+        return ss2_reply
+
+    @property
+    def source(self) -> str:
+        return str(self.doc["source"])
+
+
+class TestNormalSync:
+    """Tests for normal (non-divergent) sync handshake."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_client_syncs_successfully(self, make_yroom: MakeYRoom):
+        """A fresh client with an empty YDoc should complete the handshake."""
+        yroom = await make_yroom()
+        ws = FakeWebSocket()
+        client_id = yroom.clients.add(ws)
+
+        # Send SS1 via add_message (goes through the queue)
+        ss1 = ws.build_ss1()
+        yroom.add_message(client_id, ss1)
+
+        # Give the message queue time to process SS1 and await SS2
+        await asyncio.sleep(0.1)
+
+        # Client processes server's SS2 + SS1, gets SS2 reply
+        ss2_reply = ws.process_server_messages()
+        assert ss2_reply is not None
+
+        # Send SS2 reply back (bypasses queue via future)
+        yroom.add_message(client_id, ss2_reply)
+        await asyncio.sleep(0.1)
+
+        # Client should be synced
+        client = yroom.clients.get(client_id)
+        assert client.synced
+
+    @pytest.mark.asyncio
+    async def test_client_receives_existing_content(self, make_yroom: MakeYRoom):
+        """A fresh client should receive the server's existing content."""
+        yroom = await make_yroom()
+        jupyter_ydoc = await yroom.get_jupyter_ydoc()
+        jupyter_ydoc.source = "hello world"
+
+        ws = FakeWebSocket()
+        client_id = yroom.clients.add(ws)
+
+        ss1 = ws.build_ss1()
+        yroom.add_message(client_id, ss1)
+        await asyncio.sleep(0.1)
+
+        ss2_reply = ws.process_server_messages()
+        assert ss2_reply is not None
+        yroom.add_message(client_id, ss2_reply)
+        await asyncio.sleep(0.1)
+
+        # Client should have the server's content
+        assert ws.source == "hello world"
+
+
+class TestDivergentSync:
+    """Tests for divergent client sync (content deduplication)."""
+
+    @pytest.mark.asyncio
+    async def test_divergent_client_detected(self, make_yroom: MakeYRoom):
+        """A client with unknown client IDs should be detected as divergent."""
+        yroom = await make_yroom()
+        jupyter_ydoc = await yroom.get_jupyter_ydoc()
+        jupyter_ydoc.source = "hello world"
+
+        # Client has same content but different CRDT history
+        ws = FakeWebSocket()
+        ws.doc["source"] += "hello world"
+
+        ss1 = ws.build_ss1()
+        assert yroom._has_divergent_history(ss1[1:])
+
+    @pytest.mark.asyncio
+    async def test_divergent_client_no_duplication(self, make_yroom: MakeYRoom):
+        """After a divergent handshake, content should not be duplicated."""
+        yroom = await make_yroom()
+        jupyter_ydoc = await yroom.get_jupyter_ydoc()
+        jupyter_ydoc.source = "hello world"
+
+        # Client with same content, different history
+        ws = FakeWebSocket()
+        ws.doc["source"] += "hello world"
+        client_id = yroom.clients.add(ws)
+
+        ss1 = ws.build_ss1()
+        yroom.add_message(client_id, ss1)
+        await asyncio.sleep(0.1)
+
+        ss2_reply = ws.process_server_messages()
+        assert ss2_reply is not None
+        yroom.add_message(client_id, ss2_reply)
+        await asyncio.sleep(0.1)
+
+        # No duplication on either side
+        assert jupyter_ydoc.source == "hello world"
+        assert ws.source == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_divergent_client_no_save_during_handshake(self, make_yroom: MakeYRoom):
+        """File saves should be suppressed during the divergent handshake."""
+        yroom = await make_yroom()
+        jupyter_ydoc = await yroom.get_jupyter_ydoc()
+        jupyter_ydoc.source = "hello world"
+
+        ws = FakeWebSocket()
+        ws.doc["source"] += "hello world"
+        client_id = yroom.clients.add(ws)
+
+        ss1 = ws.build_ss1()
+        yroom.add_message(client_id, ss1)
+        await asyncio.sleep(0.1)
+
+        # During handshake, saves should be suppressed
+        assert yroom.file_api._reloading_content is True
+
+        ss2_reply = ws.process_server_messages()
+        yroom.add_message(client_id, ss2_reply)
+        await asyncio.sleep(0.1)
+
+        # After handshake, saves should be re-enabled
+        assert yroom.file_api._reloading_content is False
+
+    @pytest.mark.asyncio
+    async def test_update_buffer_paused_during_divergent_handshake(self, make_yroom: MakeYRoom):
+        """The update buffer should be paused during a divergent handshake."""
+        yroom = await make_yroom()
+        jupyter_ydoc = await yroom.get_jupyter_ydoc()
+        jupyter_ydoc.source = "hello world"
+
+        ws = FakeWebSocket()
+        ws.doc["source"] += "hello world"
+        client_id = yroom.clients.add(ws)
+
+        ss1 = ws.build_ss1()
+        yroom.add_message(client_id, ss1)
+        await asyncio.sleep(0.1)
+
+        # Buffer should be paused during handshake
+        assert yroom.update_buffer._paused is True
+
+        ss2_reply = ws.process_server_messages()
+        yroom.add_message(client_id, ss2_reply)
+        await asyncio.sleep(0.1)
+
+        # Buffer should be unpaused after handshake
+        assert yroom.update_buffer._paused is False
+
+
+class TestSyncTimeout:
+    """Tests for handshake timeout behavior."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_when_ss2_never_arrives(self, make_yroom: MakeYRoom):
+        """If the client never sends SS2, the handshake should time out and
+        the source should be restored."""
+        yroom = await make_yroom()
+        jupyter_ydoc = await yroom.get_jupyter_ydoc()
+        jupyter_ydoc.source = "hello world"
+
+        ws = FakeWebSocket()
+        ws.doc["source"] += "hello world"
+        client_id = yroom.clients.add(ws)
+
+        ss1 = ws.build_ss1()
+        yroom.add_message(client_id, ss1)
+
+        # Wait for timeout (5s + buffer)
+        await asyncio.sleep(6)
+
+        # Source should be restored
+        assert jupyter_ydoc.source == "hello world"
+        # Saves should be re-enabled
+        assert yroom.file_api._reloading_content is False
+        # Buffer should be unpaused
+        assert yroom.update_buffer._paused is False
+
+
+class TestMultipleClients:
+    """Tests for multiple clients syncing."""
+
+    @pytest.mark.asyncio
+    async def test_two_divergent_clients_sequential(self, make_yroom: MakeYRoom):
+        """Two divergent clients syncing sequentially should both get correct
+        content."""
+        yroom = await make_yroom()
+        jupyter_ydoc = await yroom.get_jupyter_ydoc()
+        jupyter_ydoc.source = "hello world"
+
+        for _ in range(2):
+            ws = FakeWebSocket()
+            ws.doc["source"] += "hello world"
+            client_id = yroom.clients.add(ws)
+
+            ss1 = ws.build_ss1()
+            yroom.add_message(client_id, ss1)
+            await asyncio.sleep(0.1)
+
+            ss2_reply = ws.process_server_messages()
+            assert ss2_reply is not None
+            yroom.add_message(client_id, ss2_reply)
+            await asyncio.sleep(0.1)
+
+            assert jupyter_ydoc.source == "hello world"
+            assert ws.source == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_fresh_then_divergent_client(self, make_yroom: MakeYRoom):
+        """A fresh client followed by a divergent client should both work."""
+        yroom = await make_yroom()
+        jupyter_ydoc = await yroom.get_jupyter_ydoc()
+        jupyter_ydoc.source = "hello world"
+
+        # Fresh client
+        ws1 = FakeWebSocket()
+        cid1 = yroom.clients.add(ws1)
+        yroom.add_message(cid1, ws1.build_ss1())
+        await asyncio.sleep(0.1)
+        ss2 = ws1.process_server_messages()
+        yroom.add_message(cid1, ss2)
+        await asyncio.sleep(0.1)
+        assert ws1.source == "hello world"
+
+        # Divergent client
+        ws2 = FakeWebSocket()
+        ws2.doc["source"] += "hello world"
+        cid2 = yroom.clients.add(ws2)
+        yroom.add_message(cid2, ws2.build_ss1())
+        await asyncio.sleep(0.1)
+        ss2 = ws2.process_server_messages()
+        yroom.add_message(cid2, ss2)
+        await asyncio.sleep(0.1)
+
+        assert jupyter_ydoc.source == "hello world"
+        assert ws2.source == "hello world"

--- a/jupyter_server_documents/websockets/clients.py
+++ b/jupyter_server_documents/websockets/clients.py
@@ -134,6 +134,7 @@ class YjsClientGroup:
         """
         Gets a client from its ID.
         """
+        client = None
         if client_id in self.desynced: 
             client = self.desynced[client_id]
         if client_id in self.synced:

--- a/jupyter_server_documents/websockets/clients.py
+++ b/jupyter_server_documents/websockets/clients.py
@@ -134,7 +134,6 @@ class YjsClientGroup:
         """
         Gets a client from its ID.
         """
-        client = None
         if client_id in self.desynced: 
             client = self.desynced[client_id]
         if client_id in self.synced:


### PR DESCRIPTION
## Demo

https://github.com/user-attachments/assets/1bc23453-415a-4839-b122-b736f83974fb

## Description

Fixes #210 

Fixes the content duplication bug that occurs in the two currently known scenarios:

- Reconnecting after restarting the server
- Reconnecting after a room was freed from memory (can be caused by closing your laptop for an hour while connected to a remote server)

In both cases, the duplication occurs because the client is connecting with an existing YDoc that has the same content but a divergent history. If the server's YDoc has a different history (e.g. it contains only a single item when it loads from disk), the histories are merged even though the content is identical, resulting in content duplication.

### Divergent history detection

To fix this, this PR implements **divergent history detection**. The `YRoom` now checks the state vector provided by each client when connecting to the `YRoom`. There are 3 scenarios:

1. State vector is totally empty: client just opened the file in their browser for first time
2. State vector is non-empty but has the same set of Yjs clients => client briefly disconnected but has the same history
3. **State vector has a different set of Yjs clients** => client has **divergent history** from a previous room session

This allows us to precisely detect when content duplication would occur.

### How content duplication is prevented

When case 3) occurs, the `YRoom` does the following to prevent content duplication:

1. Clear the YDoc to an empty state, while storing the original state
2. Queue all document updates and block saves
3. Perform the handshake as normal
4. Restore the YDoc to its original state
5. Broadcast all queued document updates and resume saving

- Step 1) prevents the reconnecting client from seeing content duplication.
- Step 2) prevents other clients from seeing an empty document while the reconnecting client is completing the handshake
- Step 3) syncs the reconnecting client
- Steps 4) + 5) gets all clients synced to the original document state as quickly as possible

This logic runs only if a connecting client has divergent history. It does not run in the "normal" circumstances (fresh connection / reconnecting after brief disconnect).

###  Consequences

- Edits made during the brief window where a client with divergent history is connecting may appear in the wrong locations.
- Other clients may see a brief flash of an empty document. This timing window has been minimized thanks to the new `YRoomUpdateBuffer`, but it may be visible very briefly on the browser.

### Additional code changes

Each sync handshake now blocks the processing of new messages until it is fully complete.

## Notes

While this solves the content duplication issue, I do not think this is the right long-term solution. We're essentially freezing edits every time a divergent client connects for every other client. This also requires clients to sync one-at-a-time since we must wait for the divergent client's SS2 reply - this can cause issues if several people try to connect to a room at the same time (e.g. in a teaching environment).

The ideal solution would be to have each **client** do the divergent history detection based on the SS1 message sent from the server after the first handshake, then reset their YDoc to a completely empty state if the client discovers that the server has diverged. Previously this is how we handled out-of-band changes. However, we discovered that this was causing UI state to get corrupted, which motivated #202.

Long-term, the right solution is to work to improve the reliability of resetting the YDoc to an empty state in the JupyterLab UI. Essentially #93 needs to work in JupyterLab without corrupting the UI - that would allow us to handle divergent clients more reliably.