### PR TITLE
fix: batched catchup in YRoomUpdateBuffer.resume()

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -677,6 +677,14 @@ class YRoom(LoggingConfigurable):
         # Mark client as desynced
         self.clients.mark_desynced(client_id)
 
+        # Save the server's state vector before the handshake. After the
+        # handshake completes, get_update(pre_sync_sv) produces a single
+        # batched diff covering any mutations that occurred during the
+        # handshake gap. This replaces replaying individual queued messages,
+        # which triggers a pycrdt offset encoding bug (#197) where
+        # incremental Text updates after multi-byte characters crash JS yjs.
+        pre_sync_sv = self._ydoc.get_state()
+
         # Check if client has divergent history
         ss1_payload = ss1_message[1:]
         divergent = self._has_divergent_history(ss1_payload)
@@ -728,13 +736,18 @@ class YRoom(LoggingConfigurable):
             self.log.exception("Exception raised during sync handshake with client '%s' in room '%s':", client_id, self.room_id)
             handshake_failed = True
 
-        # Restore the YDoc source, flush all document updates queued in the
-        # update_buffer, and resume saving, regardless of whether the handshake
+        # Restore the YDoc source, flush the update_buffer with a batched
+        # catchup diff, and resume saving, regardless of whether the handshake
         # succeeded.
         if saved_source is not None and self._jupyter_ydoc is not None:
             self._jupyter_ydoc.source = saved_source
             self.log.info("Restored YDoc source.")
-        self.update_buffer.resume()
+        catchup = self._ydoc.get_update(pre_sync_sv)
+        # An empty yjs update is 2 bytes (b"\x00\x00").
+        catchup_message = None
+        if catchup and len(catchup) > 2:
+            catchup_message = pycrdt.create_update_message(catchup)
+        self.update_buffer.resume(catchup_message=catchup_message)
         if self.file_api is not None:
             self.file_api._reloading_content = False
         

--- a/jupyter_server_documents/rooms/yroom_update_buffer.py
+++ b/jupyter_server_documents/rooms/yroom_update_buffer.py
@@ -41,13 +41,20 @@ class YRoomUpdateBuffer(LoggingConfigurable):
         """Start queuing updates instead of broadcasting them."""
         self._paused = True
 
-    def resume(self) -> None:
-        """Broadcast all queued updates and unpause."""
-        queued = self._queue
+    def resume(self, catchup_message: bytes | None = None) -> None:
+        """Discard queued updates and unpause. If catchup_message is provided,
+        broadcast it as a single batched update instead of replaying individual
+        queued messages.
+
+        Batching avoids a pycrdt offset encoding bug
+        (jupyter-ai-contrib/jupyter-server-documents#197) where individual
+        incremental Text updates after multi-byte characters crash JS yjs
+        clients with findIndexSS "Unexpected case".
+        """
         self._queue = []
         self._paused = False
-        for message in queued:
-            self._broadcast(message)
+        if catchup_message is not None:
+            self._broadcast(catchup_message)
 
     def _broadcast(self, message: bytes) -> None:
         """Send a message to all synced clients."""


### PR DESCRIPTION
## Summary

- Ports the batched catchup approach onto the `YRoomUpdateBuffer` class introduced in #215
- Saves the server's state vector before the handshake in `handle_sync()`
- After the handshake, computes a single batched diff via `ydoc.get_update(pre_sync_sv)` and passes it to `resume()`
- `resume()` broadcasts the batched diff instead of replaying individual queued messages

This fixes two issues for divergent client handshakes:

1. **Silent data loss**: updates queued during the divergent handshake are delivered as one clean diff covering the full gap
2. **findIndexSS crash (#197)**: individual incremental Text updates from pycrdt after multi-byte characters use offset encoding that JS yjs cannot resolve. A single batched update keeps all CRDT struct references resolvable within the same message.

## Changes

**`rooms/yroom.py`** — `handle_sync()`:
- Save `pre_sync_sv = self._ydoc.get_state()` before the handshake
- After handshake, compute `catchup = self._ydoc.get_update(pre_sync_sv)`
- Pass batched catchup to `self.update_buffer.resume(catchup_message=...)`

**`rooms/yroom_update_buffer.py`** — `resume()`:
- Accept optional `catchup_message` parameter
- Discard the queue and broadcast the batched message instead of replaying individual updates

## Test plan

- [x] All 22 tests pass (`pytest jupyter_server_documents/tests/test_yroom_sync.py jupyter_server_documents/tests/test_yroom.py`)
- [x] Stress tests in separate PR: #219

## Related

- Upstream pycrdt fix for the offset encoding bug: https://github.com/y-crdt/pycrdt/pull/379
- #197 (findIndexSS crash with Unicode chars)
- #215 (YRoomUpdateBuffer introduction)
- #219 (stress tests, split out per @dlqqq's request)