### PR TITLE
Fix output loss from clear_output race condition

### DIFF
--- a/jupyter_server_documents/outputs/output_processor.py
+++ b/jupyter_server_documents/outputs/output_processor.py
@@ -136,14 +136,15 @@ class OutputProcessor(LoggingConfigurable):
         if wait:
             self._pending_clear_output_cells.add(cell_id)
         else:
-            await self.clear_cell_outputs(cell_id)
+            await self._clear_ydoc_outputs(cell_id)
 
     async def output_task(self, msg_type, cell_id, content):
         """A coroutine to handle output messages."""
 
         # Check for pending clear_output before processing output
         if cell_id in self._pending_clear_output_cells:
-            await self.clear_cell_outputs(cell_id)
+            await self._clear_ydoc_outputs(cell_id)
+            self._pending_clear_output_cells.discard(cell_id)
 
         # Get file_id and path from kernel session (handles renames)
         file_id, path = await self._get_file_info()

--- a/jupyter_server_documents/tests/test_output_processor.py
+++ b/jupyter_server_documents/tests/test_output_processor.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 from pycrdt import Array, Map
@@ -41,6 +41,71 @@ def _make_output_processor(outputs_manager, file_id):
     op.use_outputs_service = True
     op._get_file_info = AsyncMock(return_value=(file_id, f"/path/to/{file_id}.ipynb"))
     return op
+
+
+class FakeNotebook:
+    """Lightweight notebook stub that uses plain Python lists for outputs."""
+
+    def __init__(self, cell_id):
+        self._cell_id = cell_id
+        self._outputs = []
+
+    def find_cell(self, cell_id):
+        if cell_id == self._cell_id:
+            return 0, {"outputs": self._outputs}
+        return -1, None
+
+
+def _make_op(fake_nb, *, file_id="file-1", use_outputs_service=True):
+    """Create an OutputProcessor wired to a FakeNotebook with all I/O mocked."""
+    op = OutputProcessorForTest()
+    op._file_id = file_id
+
+    mock_room = MagicMock()
+    mock_room.get_jupyter_ydoc = AsyncMock(return_value=fake_nb)
+
+    mock_yroom_mgr = MagicMock()
+    mock_yroom_mgr.get_room.return_value = mock_room
+
+    mock_outputs_mgr = MagicMock()
+    mock_outputs_mgr.write.side_effect = lambda **kw: kw["output"]
+    mock_outputs_mgr.get_output_index.return_value = None
+
+    mock_session_mgr = AsyncMock()
+    mock_session_mgr.get_session.return_value = {"path": "nb.ipynb"}
+
+    mock_file_id_mgr = MagicMock()
+    mock_file_id_mgr.get_id.return_value = file_id
+
+    op._test_settings = {
+        "yroom_manager": mock_yroom_mgr,
+        "outputs_manager": mock_outputs_mgr,
+        "session_manager": mock_session_mgr,
+        "file_id_manager": mock_file_id_mgr,
+    }
+    op.use_outputs_service = use_outputs_service
+    return op, mock_outputs_mgr
+
+
+@pytest.fixture
+def output_processor():
+    """Fixture that returns an instance of TestOutputProcessor."""
+    return OutputProcessorForTest()
+
+
+def create_incoming_message(cell_id):
+    msg_id = str(uuid4())
+    header = {"msg_id": msg_id, "msg_type": "execute_request"}
+    parent_header = {}
+    metadata = {"cellId": cell_id}
+    msg = [json.dumps(item) for item in [header, parent_header, metadata]]
+    return msg_id, msg
+
+
+def test_instantiation(output_processor):
+    """Test instantiation of the output processor."""
+    op = output_processor
+    assert isinstance(op, OutputProcessor)
 
 
 @pytest.mark.asyncio
@@ -129,3 +194,76 @@ async def test_output_task_update_display_after_clear_no_index_error():
 
         _, cell = notebook.find_cell(cell_id)
         assert len(cell["outputs"]) == 1
+
+
+@pytest.mark.anyio
+async def test_clear_output_task_does_not_clear_disk():
+    """clear_output from kernel should only clear YDoc, not disk."""
+    fake_nb = FakeNotebook("cell-1")
+    fake_nb._outputs.append({"output_type": "stream", "text": "hello"})
+
+    op, mock_outputs_mgr = _make_op(fake_nb)
+
+    await op.clear_output_task("cell-1", {"wait": False})
+
+    assert len(fake_nb._outputs) == 0
+    mock_outputs_mgr.clear.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_clear_cell_outputs_does_clear_disk():
+    """clear_cell_outputs (execute_request) should clear both YDoc and disk."""
+    fake_nb = FakeNotebook("cell-1")
+    fake_nb._outputs.append({"output_type": "stream", "text": "old"})
+
+    op, mock_outputs_mgr = _make_op(fake_nb)
+
+    with patch.object(type(op), "parent", new_callable=lambda: property(lambda self: MagicMock(parent=MagicMock(kernel_id="k1")))):
+        await op.clear_cell_outputs("cell-1")
+
+    assert len(fake_nb._outputs) == 0
+    mock_outputs_mgr.clear.assert_called_once_with(file_id="file-1", cell_id="cell-1")
+
+
+@pytest.mark.anyio
+async def test_clear_output_does_not_wipe_subsequent_output():
+    """Simulate one progress bar iteration: output → clear → new output."""
+    fake_nb = FakeNotebook("cell-1")
+    op, mock_outputs_mgr = _make_op(fake_nb)
+
+    fake_nb._outputs.append({"output_type": "stream", "text": "Progress: 1/10"})
+
+    await op.clear_output_task("cell-1", {"wait": False})
+    assert len(fake_nb._outputs) == 0
+
+    with patch.object(type(op), "parent", new_callable=lambda: property(lambda self: MagicMock(parent=MagicMock(kernel_id="k1")))):
+        await op.output_task("stream", "cell-1", {
+            "text": "Progress: 2/10",
+            "name": "stdout",
+        })
+    assert len(fake_nb._outputs) == 1
+    assert fake_nb._outputs[0]["text"] == "Progress: 2/10"
+
+    mock_outputs_mgr.clear.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_clear_output_wait_defers_to_next_output():
+    """clear_output(wait=True) should defer clearing until next output."""
+    fake_nb = FakeNotebook("cell-1")
+    fake_nb._outputs.append({"output_type": "stream", "text": "old"})
+
+    op, _ = _make_op(fake_nb)
+
+    await op.clear_output_task("cell-1", {"wait": True})
+    assert len(fake_nb._outputs) == 1
+    assert "cell-1" in op._pending_clear_output_cells
+
+    with patch.object(type(op), "parent", new_callable=lambda: property(lambda self: MagicMock(parent=MagicMock(kernel_id="k1")))):
+        await op.output_task("stream", "cell-1", {
+            "text": "new",
+            "name": "stdout",
+        })
+    assert len(fake_nb._outputs) == 1
+    assert fake_nb._outputs[0]["text"] == "new"
+    assert "cell-1" not in op._pending_clear_output_cells


### PR DESCRIPTION
When the kernel sends `clear_output` messages (used by progress bars, `IPython.display.clear_output()`, and any code that replaces output in-place), the output processor was handling each one the same way it handles a full cell re-execution: clear the YDoc output array AND delete output files from disk.

This is too heavy for an in-place output update. In cloud environments where the session/file_id lookup takes seconds, it creates a race condition — new output gets written while a stale clear is still in flight, and the late-arriving clear deletes the output that was just written. The frontend then gets 404s trying to fetch the output files.

The fix separates the two clear paths:

- **`clear_output` from kernel** (in-place output replacement): just clears the YDoc output array via `_clear_ydoc_outputs`. Cheap, no I/O.
- **`clear_cell_outputs` from execute_request** (cell re-execution): full pipeline — clears YDoc and deletes output files from disk.

No caching mechanism needed — `_clear_ydoc_outputs` already guards on `self._file_id` being set, so if no output has been processed yet it safely no-ops.