### PR TITLE
Allow GC to free notebook rooms with unknown execution state

### DIFF
--- a/jupyter_server_documents/rooms/yroom_manager.py
+++ b/jupyter_server_documents/rooms/yroom_manager.py
@@ -307,9 +307,9 @@ class YRoomManager(LoggingConfigurable):
 
         - For rooms providing notebooks: This task stops the room if it has is
         inactive, has no connected clients, and its kernel execution status is
-        'idle', 'dead', or unknown (None). An unknown state means no kernel
-        has reported status for this notebook — e.g. it was opened without a
-        connected kernel, or the kernel was shut down externally.
+        'idle', 'dead', 'unknown', or None. An unknown/None state means no
+        kernel has reported status for this notebook — e.g. it was opened
+        without a connected kernel, or the kernel was shut down externally.
 
         - See `YRoom.inactive` for details on how activity is measured.
         """
@@ -320,7 +320,7 @@ class YRoomManager(LoggingConfigurable):
 
         awareness = room.get_awareness().get_local_state() or {}
         execution_state = awareness.get("kernel", {}).get("execution_state", None)
-        can_free_execution_state = execution_state in { "idle", "dead", None }
+        can_free_execution_state = execution_state in { "idle", "dead", "unknown", None }
         should_free = can_free_execution_state and room.inactive_and_empty
         if self.show_gc_debug and room.empty and not should_free:
             reasons = []

--- a/jupyter_server_documents/rooms/yroom_manager.py
+++ b/jupyter_server_documents/rooms/yroom_manager.py
@@ -307,8 +307,9 @@ class YRoomManager(LoggingConfigurable):
 
         - For rooms providing notebooks: This task stops the room if it has is
         inactive, has no connected clients, and its kernel execution status is
-        'idle', 'dead', or unknown (None). An unknown state typically means
-        the kernel was already culled by the kernel monitor.
+        'idle', 'dead', or unknown (None). An unknown state means no kernel
+        has reported status for this notebook — e.g. it was opened without a
+        connected kernel, or the kernel was shut down externally.
 
         - See `YRoom.inactive` for details on how activity is measured.
         """

--- a/jupyter_server_documents/rooms/yroom_manager.py
+++ b/jupyter_server_documents/rooms/yroom_manager.py
@@ -307,7 +307,8 @@ class YRoomManager(LoggingConfigurable):
 
         - For rooms providing notebooks: This task stops the room if it has is
         inactive, has no connected clients, and its kernel execution status is
-        either 'idle' or 'dead'.
+        'idle', 'dead', or unknown (None). An unknown state typically means
+        the kernel was already culled by the kernel monitor.
 
         - See `YRoom.inactive` for details on how activity is measured.
         """
@@ -315,15 +316,16 @@ class YRoomManager(LoggingConfigurable):
             if self.show_gc_debug and room.empty and not room.inactive:
                 self.log.info(f"Not freeing room '{room.room_id}' because it is not yet inactive.")
             return room.inactive_and_empty
-        
+
         awareness = room.get_awareness().get_local_state() or {}
         execution_state = awareness.get("kernel", {}).get("execution_state", None)
-        should_free = execution_state in { "idle", "dead" } and room.inactive_and_empty
+        can_free_execution_state = execution_state in { "idle", "dead", None }
+        should_free = can_free_execution_state and room.inactive_and_empty
         if self.show_gc_debug and room.empty and not should_free:
             reasons = []
             if not room.inactive:
                 reasons.append("it is not yet inactive")
-            if execution_state not in { "idle", "dead" }:
+            if not can_free_execution_state:
                 reasons.append(f"it has execution state '{execution_state}'")
             self.log.info(f"Not freeing notebook room '{room.room_id}' because {' and '.join(reasons)}.")
         return should_free

--- a/jupyter_server_documents/tests/test_should_free_room.py
+++ b/jupyter_server_documents/tests/test_should_free_room.py
@@ -1,13 +1,34 @@
+"""
+Tests for YRoomManager._should_free_room() — the GC decision logic.
+
+The GC periodically checks each room and frees it if _should_free_room()
+returns True. For notebook rooms, the decision depends on:
+
+  1. The room must be inactive (no recent activity) AND empty (no WebSocket clients).
+  2. The kernel execution_state must be safe to free: "idle", "dead", or None.
+
+A None execution_state occurs when no kernel has ever reported status for
+the notebook — e.g. the notebook was opened without starting a kernel, or
+the kernel was shut down externally. In all these cases, there's no active
+computation to protect, so freeing is safe.
+
+Non-notebook rooms (text files, etc.) skip the execution_state check entirely
+and only require inactive_and_empty.
+"""
 from __future__ import annotations
 import pytest
 from unittest.mock import MagicMock, patch
-import pycrdt
 
 from jupyter_server_documents.rooms.yroom_manager import YRoomManager
 
 
+# Sentinel used to simulate awareness state where the "kernel" key is
+# entirely absent (as opposed to present with execution_state=None).
+_UNSET = object()
+
+
 class FakeAwareness:
-    """Minimal awareness mock that returns a configurable local state."""
+    """Returns a configurable local state dict, mimicking pycrdt.Awareness."""
 
     def __init__(self, state: dict | None = None):
         self._state = state
@@ -17,7 +38,12 @@ class FakeAwareness:
 
 
 class FakeRoom:
-    """Minimal room mock for testing _should_free_room logic."""
+    """
+    Minimal stand-in for YRoom that exposes only what _should_free_room reads:
+    - room_id: determines whether this is a notebook room ("json:notebook:...")
+    - inactive_and_empty: whether the room has no clients and has been idle
+    - get_awareness(): returns awareness with a configurable execution_state
+    """
 
     def __init__(self, room_id: str, inactive_and_empty: bool = True, execution_state=None):
         self.room_id = room_id
@@ -27,23 +53,21 @@ class FakeRoom:
         self._execution_state = execution_state
 
     def get_awareness(self):
+        # _UNSET simulates awareness where "kernel" key was never written
         if self._execution_state is _UNSET:
             return FakeAwareness({})
         return FakeAwareness({"kernel": {"execution_state": self._execution_state}})
 
 
-_UNSET = object()
-
-
 @pytest.fixture
 def manager():
-    """Create a YRoomManager with mocked parent to avoid server dependencies."""
-    mock_parent = MagicMock()
-    mock_parent.config = {}
-    mock_parent.log = MagicMock()
-    mock_parent.event_loop = MagicMock()
-    mock_parent.contents_manager = MagicMock()
+    """
+    Create a YRoomManager without initializing a real server.
 
+    We bypass __init__ because it requires a full ServerDocsApp parent with
+    contents_manager, event_loop, etc. Since _should_free_room only reads
+    self.show_gc_debug and self.log, we set those directly.
+    """
     with patch.object(YRoomManager, '__init__', lambda self, **kwargs: None):
         mgr = YRoomManager.__new__(YRoomManager)
         mgr.show_gc_debug = False
@@ -52,40 +76,61 @@ def manager():
 
 
 class TestShouldFreeNotebookRoom:
-    """Tests that _should_free_room handles notebook execution states correctly."""
+    """
+    Verifies _should_free_room for notebook rooms (room_id starts with
+    "json:notebook:"). These rooms have an additional execution_state guard
+    beyond the inactive_and_empty check.
+    """
+
+    # --- States that SHOULD allow freeing ---
 
     def test_idle_allows_free(self, manager):
+        # Kernel finished executing and is sitting idle — safe to free.
         room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state="idle")
         assert manager._should_free_room(room) is True
 
     def test_dead_allows_free(self, manager):
+        # Kernel process has terminated — nothing left to protect.
         room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state="dead")
         assert manager._should_free_room(room) is True
 
     def test_none_allows_free(self, manager):
-        """None execution state (kernel culled) should allow freeing."""
+        # execution_state is None when the kernel was shut down externally
+        # (e.g. culled for inactivity) and no final status was written to
+        # awareness. The room is orphaned — safe to free.
         room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state=None)
         assert manager._should_free_room(room) is True
 
     def test_missing_kernel_key_allows_free(self, manager):
-        """No kernel key in awareness (never started) should allow freeing."""
+        # The "kernel" key was never written to awareness — this happens when
+        # a notebook is opened but no kernel is ever started. Since there's
+        # no kernel, there's no computation to protect.
         room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state=_UNSET)
         assert manager._should_free_room(room) is True
 
+    # --- States that SHOULD block freeing ---
+
     def test_busy_blocks_free(self, manager):
+        # Kernel is actively executing — freeing would discard live state.
         room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state="busy")
         assert manager._should_free_room(room) is False
 
     def test_starting_blocks_free(self, manager):
+        # Kernel is starting up — freeing could race with initialization.
         room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state="starting")
         assert manager._should_free_room(room) is False
 
     def test_not_inactive_blocks_free(self, manager):
-        """Even with idle kernel, active room should not be freed."""
+        # Even with an idle kernel, if the room still has recent activity or
+        # connected clients, we must not free it — someone may reconnect.
         room = FakeRoom("json:notebook:abc123", inactive_and_empty=False, execution_state="idle")
         assert manager._should_free_room(room) is False
 
+    # --- Non-notebook rooms ---
+
     def test_non_notebook_room_ignores_execution_state(self, manager):
-        """Non-notebook rooms only check inactive_and_empty."""
+        # Text/file rooms don't have kernels. The execution_state is irrelevant;
+        # only inactive_and_empty matters. Here we set execution_state="busy"
+        # to prove it's ignored for non-notebook rooms.
         room = FakeRoom("text:file:abc123", inactive_and_empty=True, execution_state="busy")
         assert manager._should_free_room(room) is True

--- a/jupyter_server_documents/tests/test_should_free_room.py
+++ b/jupyter_server_documents/tests/test_should_free_room.py
@@ -5,7 +5,7 @@ The GC periodically checks each room and frees it if _should_free_room()
 returns True. For notebook rooms, the decision depends on:
 
   1. The room must be inactive (no recent activity) AND empty (no WebSocket clients).
-  2. The kernel execution_state must be safe to free: "idle", "dead", or None.
+  2. The kernel execution_state must be safe to free: "idle", "dead", "unknown", or None.
 
 A None execution_state occurs when no kernel has ever reported status for
 the notebook — e.g. the notebook was opened without starting a kernel, or
@@ -99,6 +99,13 @@ class TestShouldFreeNotebookRoom:
         # (e.g. culled for inactivity) and no final status was written to
         # awareness. The room is orphaned — safe to free.
         room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state=None)
+        assert manager._should_free_room(room) is True
+
+    def test_unknown_string_allows_free(self, manager):
+        # "unknown" is an explicit execution state that may be set when the
+        # kernel status cannot be determined. Same semantics as None — no
+        # active computation to protect.
+        room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state="unknown")
         assert manager._should_free_room(room) is True
 
     def test_missing_kernel_key_allows_free(self, manager):

--- a/jupyter_server_documents/tests/test_should_free_room.py
+++ b/jupyter_server_documents/tests/test_should_free_room.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+import pytest
+from unittest.mock import MagicMock, patch
+import pycrdt
+
+from jupyter_server_documents.rooms.yroom_manager import YRoomManager
+
+
+class FakeAwareness:
+    """Minimal awareness mock that returns a configurable local state."""
+
+    def __init__(self, state: dict | None = None):
+        self._state = state
+
+    def get_local_state(self):
+        return self._state
+
+
+class FakeRoom:
+    """Minimal room mock for testing _should_free_room logic."""
+
+    def __init__(self, room_id: str, inactive_and_empty: bool = True, execution_state=None):
+        self.room_id = room_id
+        self.inactive_and_empty = inactive_and_empty
+        self.inactive = inactive_and_empty
+        self.empty = inactive_and_empty
+        self._execution_state = execution_state
+
+    def get_awareness(self):
+        if self._execution_state is _UNSET:
+            return FakeAwareness({})
+        return FakeAwareness({"kernel": {"execution_state": self._execution_state}})
+
+
+_UNSET = object()
+
+
+@pytest.fixture
+def manager():
+    """Create a YRoomManager with mocked parent to avoid server dependencies."""
+    mock_parent = MagicMock()
+    mock_parent.config = {}
+    mock_parent.log = MagicMock()
+    mock_parent.event_loop = MagicMock()
+    mock_parent.contents_manager = MagicMock()
+
+    with patch.object(YRoomManager, '__init__', lambda self, **kwargs: None):
+        mgr = YRoomManager.__new__(YRoomManager)
+        mgr.show_gc_debug = False
+        mgr.log = MagicMock()
+    return mgr
+
+
+class TestShouldFreeNotebookRoom:
+    """Tests that _should_free_room handles notebook execution states correctly."""
+
+    def test_idle_allows_free(self, manager):
+        room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state="idle")
+        assert manager._should_free_room(room) is True
+
+    def test_dead_allows_free(self, manager):
+        room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state="dead")
+        assert manager._should_free_room(room) is True
+
+    def test_none_allows_free(self, manager):
+        """None execution state (kernel culled) should allow freeing."""
+        room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state=None)
+        assert manager._should_free_room(room) is True
+
+    def test_missing_kernel_key_allows_free(self, manager):
+        """No kernel key in awareness (never started) should allow freeing."""
+        room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state=_UNSET)
+        assert manager._should_free_room(room) is True
+
+    def test_busy_blocks_free(self, manager):
+        room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state="busy")
+        assert manager._should_free_room(room) is False
+
+    def test_starting_blocks_free(self, manager):
+        room = FakeRoom("json:notebook:abc123", inactive_and_empty=True, execution_state="starting")
+        assert manager._should_free_room(room) is False
+
+    def test_not_inactive_blocks_free(self, manager):
+        """Even with idle kernel, active room should not be freed."""
+        room = FakeRoom("json:notebook:abc123", inactive_and_empty=False, execution_state="idle")
+        assert manager._should_free_room(room) is False
+
+    def test_non_notebook_room_ignores_execution_state(self, manager):
+        """Non-notebook rooms only check inactive_and_empty."""
+        room = FakeRoom("text:file:abc123", inactive_and_empty=True, execution_state="busy")
+        assert manager._should_free_room(room) is True


### PR DESCRIPTION
When a notebook room's kernel is shut down externally (or was never started),
the execution_state in awareness remains None or "unknown". Previously,
`_should_free_room` only allowed freeing rooms with execution_state "idle" or
"dead", so these orphaned rooms would stay in memory forever.

Now None and "unknown" are treated as freeable states. The `inactive_and_empty`
guard still prevents freeing rooms with connected clients or recent activity, so
there's no risk of dropping state that someone is actively using.

Also adds focused unit tests for `_should_free_room` covering all execution
state variants — idle, dead, None, "unknown", missing kernel key, busy,
starting, and the inactive guard.