### PR TITLE
fix: batched catchup in YRoomUpdateChannel.resume()

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -14,7 +14,7 @@ import traitlets
 from ..websockets import YjsClientGroup
 from .yroom_file_api import YRoomFileAPI
 from .yroom_events_api import YRoomEventsAPI
-from .yroom_update_buffer import YRoomUpdateBuffer
+from .yroom_update_channel import YRoomUpdateChannel
 
 if TYPE_CHECKING:
     import logging
@@ -223,7 +223,7 @@ class YRoom(LoggingConfigurable):
     `YRoomManager.show_gc_debug` trait.
     """
 
-    update_buffer: YRoomUpdateBuffer
+    update_channel: YRoomUpdateChannel
     """
     Buffer for all SyncUpdate messages. See class docstring for more details.
     """
@@ -255,8 +255,8 @@ class YRoom(LoggingConfigurable):
         self._ydoc = self._init_ydoc()
         self._awareness = self._init_awareness(ydoc=self._ydoc)
 
-        # Initialize YRoomUpdateBuffer
-        self.update_buffer = YRoomUpdateBuffer(parent=self)
+        # Initialize YRoomUpdateChannel
+        self.update_channel = YRoomUpdateChannel(parent=self)
 
         # If this room is providing global awareness, set unused optional
         # attributes to `None`.
@@ -643,7 +643,7 @@ class YRoom(LoggingConfigurable):
         d = pycrdt.Decoder(sv)
         return {d.read_var_uint(): d.read_var_uint() for _ in range(d.read_var_uint())}
 
-    def _has_divergent_history(self, message_payload: bytes) -> bool:
+    def _has_divergent_history(self, message_payload: bytes, server_sv_bytes: bytes) -> bool:
         """Returns True if the client's state vector contains client IDs
         unknown to the server, indicating a stale client from a previous
         session."""
@@ -655,7 +655,7 @@ class YRoom(LoggingConfigurable):
         client_sv = self._decode_state_vector(sv_bytes)
         if not client_sv:
             return False
-        server_sv = self._decode_state_vector(self._ydoc.get_state())
+        server_sv = self._decode_state_vector(server_sv_bytes)
         return bool(set(client_sv) - set(server_sv))
 
     async def handle_sync(self, client_id: str, ss1_message: bytes) -> None:
@@ -687,7 +687,7 @@ class YRoom(LoggingConfigurable):
 
         # Check if client has divergent history
         ss1_payload = ss1_message[1:]
-        divergent = self._has_divergent_history(ss1_payload)
+        divergent = self._has_divergent_history(ss1_payload, pre_sync_sv)
 
         # If divergent, pause update broadcasts and file saves then clear the
         # YDoc source to prevent content duplication.
@@ -698,7 +698,7 @@ class YRoom(LoggingConfigurable):
                 client_id,
                 self.room_id
             )
-            self.update_buffer.pause()
+            self.update_channel.pause()
             if self.file_api is not None:
                 self.file_api._reloading_content = True
             # reset JupyterYDoc source
@@ -736,18 +736,13 @@ class YRoom(LoggingConfigurable):
             self.log.exception("Exception raised during sync handshake with client '%s' in room '%s':", client_id, self.room_id)
             handshake_failed = True
 
-        # Restore the YDoc source, flush the update_buffer with a batched
+        # Restore the YDoc source, flush the update_channel with a batched
         # catchup diff, and resume saving, regardless of whether the handshake
         # succeeded.
         if saved_source is not None and self._jupyter_ydoc is not None:
             self._jupyter_ydoc.source = saved_source
             self.log.info("Restored YDoc source.")
-        catchup = self._ydoc.get_update(pre_sync_sv)
-        # An empty yjs update is 2 bytes (b"\x00\x00").
-        catchup_message = None
-        if catchup and len(catchup) > 2:
-            catchup_message = pycrdt.create_update_message(catchup)
-        self.update_buffer.resume(catchup_message=catchup_message)
+        self.update_channel.resume(pre_sync_sv=pre_sync_sv)
         if self.file_api is not None:
             self.file_api._reloading_content = False
         
@@ -867,7 +862,7 @@ class YRoom(LoggingConfigurable):
         self._update_activity("_on_ydoc_update")
         update: bytes = event.update
         message = pycrdt.create_update_message(update)
-        self.update_buffer.send_update(message)
+        self.update_channel.send_update(message)
 
 
     def add_stop_callback(self, callback: Callable[[], Any]) -> None:

--- a/jupyter_server_documents/rooms/yroom_update_channel.py
+++ b/jupyter_server_documents/rooms/yroom_update_channel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pycrdt
 from typing import TYPE_CHECKING
 from traitlets.config import LoggingConfigurable
 
@@ -8,13 +9,13 @@ if TYPE_CHECKING:
     from ..websockets import YjsClientGroup
 
 
-class YRoomUpdateBuffer(LoggingConfigurable):
+class YRoomUpdateChannel(LoggingConfigurable):
     """
     Broadcasts SyncUpdate messages to connected clients normally, queues them
     when paused, and flushes queued messages when resumed.
 
     When a client with divergent history syncs, we clear the YDoc before the
-    handshake and restore it after. Pausing the buffer prevents other clients
+    handshake and restore it after. Pausing the channel prevents other clients
     from seeing a flash of empty content.
     """
 
@@ -41,10 +42,9 @@ class YRoomUpdateBuffer(LoggingConfigurable):
         """Start queuing updates instead of broadcasting them."""
         self._paused = True
 
-    def resume(self, catchup_message: bytes | None = None) -> None:
-        """Discard queued updates and unpause. If catchup_message is provided,
-        broadcast it as a single batched update instead of replaying individual
-        queued messages.
+    def resume(self, pre_sync_sv: bytes) -> None:
+        """Discard queued updates and unpause. Computes a single batched
+        catchup diff from pre_sync_sv and broadcasts it if non-empty.
 
         Batching avoids a pycrdt offset encoding bug
         (jupyter-ai-contrib/jupyter-server-documents#197) where individual
@@ -53,8 +53,10 @@ class YRoomUpdateBuffer(LoggingConfigurable):
         """
         self._queue = []
         self._paused = False
-        if catchup_message is not None:
-            self._broadcast(catchup_message)
+        catchup = self.parent._ydoc.get_update(pre_sync_sv)
+        # An empty yjs update is 2 bytes (b"\x00\x00").
+        if catchup and len(catchup) > 2:
+            self._broadcast(pycrdt.create_update_message(catchup))
 
     def _broadcast(self, message: bytes) -> None:
         """Send a message to all synced clients."""

--- a/jupyter_server_documents/rooms/yroom_update_channel.py
+++ b/jupyter_server_documents/rooms/yroom_update_channel.py
@@ -10,13 +10,12 @@ if TYPE_CHECKING:
 
 
 class YRoomUpdateChannel(LoggingConfigurable):
-    """
-    Broadcasts SyncUpdate messages to connected clients normally, queues them
-    when paused, and flushes queued messages when resumed.
+    """Broadcast channel for SyncUpdate messages that can be paused and resumed.
 
-    When a client with divergent history syncs, we clear the YDoc before the
-    handshake and restore it after. Pausing the channel prevents other clients
-    from seeing a flash of empty content.
+    When a client with divergent history syncs, the channel is paused to
+    suppress broadcasts while the YDoc source is temporarily cleared. On
+    resume, a single batched catchup diff is computed and broadcast to bring
+    other clients up to date.
     """
 
     parent: YRoom
@@ -24,34 +23,30 @@ class YRoomUpdateChannel(LoggingConfigurable):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._paused = False
-        self._queue: list[bytes] = []
 
     @property
     def clients(self) -> YjsClientGroup:
         return self.parent.clients
 
     def send_update(self, message: bytes) -> None:
-        """Broadcast a SyncUpdate message to all synced clients, or queue it
+        """Broadcast a SyncUpdate message to all synced clients, or discard it
         if paused."""
         if self._paused:
-            self._queue.append(message)
             return
         self._broadcast(message)
 
     def pause(self) -> None:
-        """Start queuing updates instead of broadcasting them."""
+        """Suppress broadcasts until resume() is called."""
         self._paused = True
 
     def resume(self, pre_sync_sv: bytes) -> None:
-        """Discard queued updates and unpause. Computes a single batched
-        catchup diff from pre_sync_sv and broadcasts it if non-empty.
+        """Unpause and broadcast a single batched catchup diff covering all
+        mutations since pre_sync_sv.
 
-        Batching avoids a pycrdt offset encoding bug
-        (jupyter-ai-contrib/jupyter-server-documents#197) where individual
+        Batching avoids a pycrdt offset-encoding bug (#197) where individual
         incremental Text updates after multi-byte characters crash JS yjs
         clients with findIndexSS "Unexpected case".
         """
-        self._queue = []
         self._paused = False
         catchup = self.parent._ydoc.get_update(pre_sync_sv)
         # An empty yjs update is 2 bytes (b"\x00\x00").

--- a/jupyter_server_documents/tests/test_yroom_sync.py
+++ b/jupyter_server_documents/tests/test_yroom_sync.py
@@ -149,7 +149,7 @@ class TestDivergentSync:
         ws.doc["source"] += "hello world"
 
         ss1 = ws.build_ss1()
-        assert yroom._has_divergent_history(ss1[1:])
+        assert yroom._has_divergent_history(ss1[1:], yroom._ydoc.get_state())
 
     @pytest.mark.asyncio
     async def test_divergent_client_no_duplication(self, make_yroom: MakeYRoom):
@@ -202,7 +202,7 @@ class TestDivergentSync:
         assert yroom.file_api._reloading_content is False
 
     @pytest.mark.asyncio
-    async def test_update_buffer_paused_during_divergent_handshake(self, make_yroom: MakeYRoom):
+    async def test_update_channel_paused_during_divergent_handshake(self, make_yroom: MakeYRoom):
         """The update buffer should be paused during a divergent handshake."""
         yroom = await make_yroom()
         jupyter_ydoc = await yroom.get_jupyter_ydoc()
@@ -217,14 +217,14 @@ class TestDivergentSync:
         await asyncio.sleep(0.1)
 
         # Buffer should be paused during handshake
-        assert yroom.update_buffer._paused is True
+        assert yroom.update_channel._paused is True
 
         ss2_reply = ws.process_server_messages()
         yroom.add_message(client_id, ss2_reply)
         await asyncio.sleep(0.1)
 
         # Buffer should be unpaused after handshake
-        assert yroom.update_buffer._paused is False
+        assert yroom.update_channel._paused is False
 
 
 class TestSyncTimeout:
@@ -253,7 +253,7 @@ class TestSyncTimeout:
         # Saves should be re-enabled
         assert yroom.file_api._reloading_content is False
         # Buffer should be unpaused
-        assert yroom.update_buffer._paused is False
+        assert yroom.update_channel._paused is False
 
 
 class TestMultipleClients:


### PR DESCRIPTION
Addresses review feedback from #218. The duplicate `self._ydoc.get_state()` call is eliminated by computing the server state vector once in `handle_sync()` and passing it to both `_has_divergent_history()` and `resume()`. The catchup diff computation is moved into `resume(pre_sync_sv)` so the caller no longer needs to assemble the catchup message—`YRoomUpdateChannel` owns that responsibility end-to-end.

Also renames `YRoomUpdateBuffer` to `YRoomUpdateChannel` (and the corresponding file and attribute) to better reflect that it is a broadcast channel that can be paused/resumed, not a traditional buffer that replays queued messages.