### PR TITLE
ci: add dedicated unit tests workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,6 @@ jobs:
           set -eux
           python -m pip install .[test]
 
-          pytest -vv -r ap --cov jupyter_server_documents
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "jupyter_server_documents.*OK"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,34 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    name: 'Python ${{ matrix.python-version }}'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: python -m pip install -e .[test]
+
+      - name: Run tests
+        run: pytest -vv -r ap --cov jupyter_server_documents

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Pytest
 
 on:
   push:


### PR DESCRIPTION
Previously, the build workflow ran unit tests, which blocked other CI jobs from starting. This led to slower than ideal CI runs on our PRs.

This PR moves pytest unit tests out of the `build.yml` workflow into a new `unit-tests.yml` workflow that runs across Python 3.10–3.13 in parallel.

## Changes
- **New**: `.github/workflows/unit-tests.yml` — runs `pytest` with coverage on a Python version matrix (3.10, 3.11, 3.12, 3.13)
- **Modified**: `.github/workflows/build.yml` — removed the `pytest` invocation from the build job (extension verification remains)