### PR TITLE
Fix kernel consoles

### DIFF
--- a/jupyter_server_documents/kernels/kernel_client.py
+++ b/jupyter_server_documents/kernels/kernel_client.py
@@ -302,9 +302,13 @@ class DocumentAwareKernelClient(AsyncKernelClient):
                             break
 
             case "stream" | "display_data" | "execute_result" | "error" | "update_display_data" | "clear_output":
-                if cell_id: 
+                if cell_id:
+                    # If no YRooms are registered (e.g. kernel consoles), let
+                    # the message pass through to listeners unmodified.
+                    if not self._yrooms:
+                        pass
                     # Process specific output messages through an optional processor
-                    if self.output_processor:
+                    elif self.output_processor:
                         content = self.session.unpack(dmsg["content"])
                         self.output_processor.process_output(dmsg['msg_type'], cell_id, content)
                         

--- a/jupyter_server_documents/session_manager.py
+++ b/jupyter_server_documents/session_manager.py
@@ -35,15 +35,25 @@ class YDocSessionManager(SessionManager):
     Dictionary of room IDs, keyed by session ID.
     """
 
+    _console_session_ids: set[str]
+    """
+    Set of session IDs that belong to kernel consoles (no backing YDoc).
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._room_ids = {}
+        self._console_session_ids = set()
 
     def get_kernel_client(self, kernel_id: str) -> DocumentAwareKernelClient:
         """Get the kernel client for a running kernel."""
         kernel_manager = self.kernel_manager.get_kernel(kernel_id)
         kernel_client = kernel_manager.main_client
         return kernel_client
+
+    def _is_console_session(self, session_id: str) -> bool:
+        """Returns True if the session is a kernel console (no backing YDoc)."""
+        return session_id in self._console_session_ids
 
     def get_yroom(self, session_id: str) -> YRoom:
         """
@@ -95,7 +105,14 @@ class YDocSessionManager(SessionManager):
         if kernel_id is None:
             kernel_id = session_model["kernel"]["id"]
 
-        # If the type is not 'notebook', return the session model immediately
+        # If this is a kernel console, return the session model early, as there
+        # is no YRoom or shared model backing the console.
+        if type == "console":
+            self._console_session_ids.add(session_id)
+            return session_model
+
+        # If the type is not 'notebook', return the session model early and log
+        # a warning.
         if type != "notebook":
             self.log.warning(
                 f"Document type '{type}' is not recognized by YDocSessionManager."
@@ -147,6 +164,10 @@ class YDocSessionManager(SessionManager):
         # Apply update and return early if `kernel_id` was not updated
         if "kernel_id" not in update:
             return await super().update_session(session_id, **update)
+
+        # Skip YRoom operations for non-notebook sessions (e.g. consoles)
+        if self._is_console_session(session_id):
+            return await super().update_session(session_id, **update)
         
         # Otherwise, first remove the YRoom from the old kernel client and add
         # the YRoom to the new kernel client, before applying the update.
@@ -173,6 +194,11 @@ class YDocSessionManager(SessionManager):
         """
         Deletes the session and disconnects the yroom from the kernel client.
         """
+        # Skip YRoom operations for non-notebook sessions (e.g. consoles)
+        if self._is_console_session(session_id):
+            self._console_session_ids.discard(session_id)
+            return await super().delete_session(session_id)
+
         session = await self.get_session(session_id=session_id)
         kernel_id = session["kernel"]["id"]
 

--- a/jupyter_server_documents/tests/kernels/test_kernel_client.py
+++ b/jupyter_server_documents/tests/kernels/test_kernel_client.py
@@ -103,3 +103,92 @@ class TestDocumentAwareKernelClient:
                 
                 mock_handle_doc.assert_not_called()
                 mock_send.assert_called_once_with("control", msg)
+
+
+class TestConsoleOutputPassthrough:
+    """Tests for kernel console output passthrough (#225).
+
+    When no YRooms are registered (e.g. kernel consoles), output messages
+    must pass through to listeners unmodified rather than being intercepted
+    by the output processor.
+    """
+
+    def _make_msg(self, session, msg_type, parent_msg_id, cell_id, content):
+        """Build a properly signed message list for handle_document_related_message."""
+        msg = session.msg(msg_type, content=content)
+        msg["parent_header"] = {"msg_id": parent_msg_id}
+        # Serialize produces: [ident, delimiter, signature, header, parent, metadata, content, buffers...]
+        # handle_document_related_message expects the parts after delimiter: [sig, header, parent, meta, content, ...]
+        parts = session.serialize(msg)
+        # session.serialize returns [ident_bytes..., DELIM, sig, header, parent, meta, content, buffers]
+        # feed_identities strips idents+delim, returning the rest
+        _, msg_list = session.feed_identities(parts)
+        return msg_list
+
+    @pytest.mark.asyncio
+    async def test_output_passes_through_without_yrooms(self):
+        """Output messages must not be suppressed when _yrooms is empty."""
+        from jupyter_client.session import Session
+
+        client = DocumentAwareKernelClient()
+        session = Session(key=b"test-key")
+        client.session = session
+
+        cell_id = "cell-123"
+        parent_msg_id = "msg-456"
+
+        client.message_cache.add({
+            "msg_id": parent_msg_id,
+            "channel": "shell",
+            "cell_id": cell_id
+        })
+
+        msg_list = self._make_msg(
+            session, "stream", parent_msg_id, cell_id,
+            {"text": "hello\n", "name": "stdout"}
+        )
+
+        # No yrooms registered (console scenario)
+        assert len(client._yrooms) == 0
+
+        result = await client.handle_document_related_message(msg_list)
+
+        # Message should pass through (not None)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_output_suppressed_with_yrooms(self):
+        """Output messages must be intercepted when _yrooms is non-empty."""
+        from jupyter_client.session import Session
+
+        client = DocumentAwareKernelClient()
+        session = Session(key=b"test-key")
+        client.session = session
+
+        cell_id = "cell-123"
+        parent_msg_id = "msg-456"
+
+        client.message_cache.add({
+            "msg_id": parent_msg_id,
+            "channel": "shell",
+            "cell_id": cell_id
+        })
+
+        msg_list = self._make_msg(
+            session, "stream", parent_msg_id, cell_id,
+            {"text": "hello\n", "name": "stdout"}
+        )
+
+        # Add a mock yroom (notebook scenario)
+        mock_yroom = MagicMock()
+        client._yrooms.add(mock_yroom)
+
+        with patch.object(client.output_processor, 'process_output') as mock_process:
+            result = await client.handle_document_related_message(msg_list)
+
+        # Message should be suppressed (output processor handled it)
+        assert result is None
+        mock_process.assert_called_once()
+        args = mock_process.call_args[0]
+        assert args[0] == "stream"
+        assert args[1] == cell_id

--- a/jupyter_server_documents/tests/test_session_manager.py
+++ b/jupyter_server_documents/tests/test_session_manager.py
@@ -226,3 +226,74 @@ class TestCreateSessionStopCallback:
         # the user to their kernel when they return.
         assert session_id in session_manager._room_ids
         assert session_manager._room_ids[session_id] == room_id
+
+
+class TestConsoleSessionHandling:
+    """Tests for kernel console session support (#225).
+
+    Console sessions have no backing YDoc or YRoom. The session manager
+    must skip all YRoom operations for consoles and delegate directly to
+    the parent SessionManager.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_session_console_skips_yroom_setup(self, session_manager):
+        """Console sessions must not set up a YRoom or touch file_id_manager."""
+        session_id = "console-session-1"
+        kernel_id = "kernel-789"
+
+        mock_session = {"id": session_id, "kernel": {"id": kernel_id}}
+        with patch('jupyter_server.services.sessions.sessionmanager.SessionManager.create_session', new_callable=AsyncMock) as mock_parent:
+            mock_parent.return_value = mock_session
+            result = await session_manager.create_session(
+                path="console-1-abc123",
+                name="console-1-abc123",
+                type="console",
+                kernel_name="python3"
+            )
+
+        # Session model returned normally
+        assert result == mock_session
+
+        # Console tracked in _console_session_ids
+        assert session_id in session_manager._console_session_ids
+
+        # No YRoom setup attempted
+        session_manager.file_id_manager.index.assert_not_called()
+        session_manager.yroom_manager.get_room.assert_not_called()
+
+        # No room_id stored
+        assert session_id not in session_manager._room_ids
+
+    @pytest.mark.asyncio
+    async def test_update_session_console_delegates_to_parent(self, session_manager):
+        """update_session on a console must not attempt YRoom operations."""
+        session_id = "console-session-1"
+        session_manager._console_session_ids.add(session_id)
+
+        with patch('jupyter_server.services.sessions.sessionmanager.SessionManager.update_session', new_callable=AsyncMock) as mock_parent:
+            await session_manager.update_session(session_id, kernel_id="new-kernel")
+
+        mock_parent.assert_called_once_with(session_id, kernel_id="new-kernel")
+        # No kernel client lookup attempted
+        session_manager.serverapp.kernel_manager.get_kernel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_session_console_delegates_to_parent(self, session_manager):
+        """delete_session on a console must not attempt YRoom operations."""
+        session_id = "console-session-1"
+        session_manager._console_session_ids.add(session_id)
+
+        with patch('jupyter_server.services.sessions.sessionmanager.SessionManager.delete_session', new_callable=AsyncMock) as mock_parent:
+            await session_manager.delete_session(session_id)
+
+        mock_parent.assert_called_once_with(session_id)
+        # Console ID cleaned up
+        assert session_id not in session_manager._console_session_ids
+
+    def test_is_console_session(self, session_manager):
+        """_is_console_session returns True only for tracked console sessions."""
+        assert not session_manager._is_console_session("some-session")
+        session_manager._console_session_ids.add("console-1")
+        assert session_manager._is_console_session("console-1")
+        assert not session_manager._is_console_session("notebook-1")


### PR DESCRIPTION
## Summary

Fixes #225. Kernel consoles were completely broken after installing jupyter-server-documents because:

1. The output processor intercepted and suppressed console output messages (returning `None` from `handle_document_related_message`), preventing them from reaching the frontend websocket listeners.
2. `update_session()` and `delete_session()` would crash with `LookupError` when called on non-notebook sessions that had no YRoom registered.

## Changes

**`session_manager.py`:**
- Track console session IDs explicitly via `_console_session_ids` set
- Add `_is_console_session()` helper method
- Skip YRoom operations in `create_session`, `update_session`, and `delete_session` for console sessions

**`kernel_client.py`:**
- Skip output processor interception when no YRooms are registered (i.e. kernel consoles), letting messages pass through to listeners unmodified

## Testing

All 185 existing tests pass. Added 6 new unit tests.