### PR TITLE
[Bug] Fix out-of-band reload cascade after room restart

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -1125,10 +1125,13 @@ class YRoom(LoggingConfigurable):
         self._message_queue.put_nowait(None)
         
         # If this room is a document room, stop the file API and save the
-        # previous content if `immediately=False`.
+        # previous content if `immediately=False` and not restarting. When
+        # restarting, the content will be reloaded from disk, so saving the
+        # old state is unnecessary and can cause timestamp mismatches that
+        # trigger the out-of-band reload cascade.
         if self.file_api and self._jupyter_ydoc:
             self.file_api.stop()
-            if not immediately:
+            if not immediately and not restarting:
                 prev_jupyter_ydoc = self._jupyter_ydoc
                 self._save_task = asyncio.create_task(
                     self.file_api.save(prev_jupyter_ydoc)

--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -1060,10 +1060,10 @@ class YRoom(LoggingConfigurable):
     def stop(self, close_code: int = 1001, immediately: bool = False, restarting: bool = False) -> None:
         """
         Stops the YRoom. This method:
-         
+
         - Disconnects all clients with the given `close_code`,
         defaulting to `1001` (server shutting down) if not given.
-        
+
         - Removes all observers and stops the `_process_message_queue()`
         background task.
 
@@ -1071,6 +1071,9 @@ class YRoom(LoggingConfigurable):
         pending updates in the message queue and save the YDoc before returning.
         Otherwise, if `immediately=True`, this method will drop all pending
         updates and not save the YDoc before returning.
+
+        - If `restarting=True`, the final save is also skipped regardless of
+        `immediately`, since content will be reloaded from disk.
 
         - Clears the YDoc, Awareness, and JupyterYDoc, freeing their memory to
         the server. This deletes the YDoc history.

--- a/jupyter_server_documents/rooms/yroom_file_api.py
+++ b/jupyter_server_documents/rooms/yroom_file_api.py
@@ -431,14 +431,17 @@ class YRoomFileAPI(LoggingConfigurable):
         while True:
             try:
                 await asyncio.sleep(self._adaptive_poll_interval)
-                await self._check_file(jupyter_ydoc)
                 if self._save_scheduled:
-                    # `asyncio.shield()` prevents the save task from being
-                    # cancelled halfway and corrupting the file. We need to
-                    # store a reference to the shielded task to prevent it from
-                    # being garbage collected (see `asyncio.shield()` docs).
+                    # Save pending changes before checking for out-of-band
+                    # modifications. Checking first would detect a mismatch
+                    # between _last_modified and the file mtime (caused by a
+                    # concurrent save task from restart or filesystem timing)
+                    # and trigger a reload that overwrites the pending YDoc
+                    # mutation — creating an infinite reload cascade.
                     save_task = self.save(jupyter_ydoc)
                     await asyncio.shield(save_task)
+                else:
+                    await self._check_file(jupyter_ydoc)
             except asyncio.CancelledError:
                 break
             except Exception:

--- a/jupyter_server_documents/tests/test_yroom_file_api.py
+++ b/jupyter_server_documents/tests/test_yroom_file_api.py
@@ -1,7 +1,10 @@
 import pytest
 import pytest_asyncio
+import asyncio
 import shutil
 from pathlib import Path
+from datetime import datetime, timezone
+from unittest.mock import patch, AsyncMock, MagicMock
 import os
 from typing import Awaitable
 import pycrdt
@@ -120,5 +123,138 @@ async def test_load_plaintext_file(
     assert jupyter_ydoc.source == content
     
     # stop file file api to avoid coroutine warnings
+    file_api.stop()
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_save_before_oob_check_prevents_reload_cascade(
+    plaintext_file_api: YRoomFileAPI,
+    empty_yunicode: YUnicode,
+    mock_plaintext_file: str,
+):
+    """Verify that pending saves run before OOB checks, preventing a reload
+    cascade when the file mtime is stale.
+
+    Background:
+        When a YRoom is garbage collected (freed after inactivity) and later
+        re-initialized, _last_modified holds the timestamp from the ORIGINAL
+        session (e.g. hours ago). Meanwhile, other code (like the output
+        processor clearing cell outputs) mutates the YDoc and calls
+        schedule_save(). The _watch_file loop then wakes up for its next tick.
+
+    The bug (before fix):
+        1. _check_file() runs first, asks ContentsManager for the file's mtime
+        2. Compares mtime against _last_modified — they differ because
+           _last_modified is stale from the old session
+        3. Concludes "out-of-band change!" and calls _reload_content_inplace()
+        4. Reload reads the file from disk and overwrites the YDoc — undoing
+           the output clear
+        5. The overwritten YDoc triggers another schedule_save(), and the cycle
+           repeats every 500ms indefinitely
+
+    The fix:
+        When _save_scheduled is True, save() runs FIRST (updating the file and
+        _last_modified), and _check_file is skipped entirely for that tick. On
+        the next tick, _last_modified matches the file mtime, so no spurious
+        reload occurs.
+
+    What this test does:
+        - Loads a file into the YDoc
+        - Mutates the YDoc and schedules a save (simulating _clear_ydoc_outputs)
+        - Sets _last_modified to a stale timestamp (simulating post-GC restart)
+        - Runs one tick of the fixed _watch_file logic
+        - Asserts that save ran (not reload), content was persisted, and
+          _last_modified was updated
+    """
+    file_api = plaintext_file_api
+    jupyter_ydoc = empty_yunicode
+    file_api.load_content_into(jupyter_ydoc)
+    await file_api.until_content_loaded
+
+    # Simulate a YDoc mutation + schedule_save (like _clear_ydoc_outputs would)
+    jupyter_ydoc.source = "modified content"
+    file_api.schedule_save()
+
+    # Simulate stale _last_modified (as happens after room GC + restart)
+    stale_time = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    file_api._last_modified = stale_time
+
+    # Run one tick of the watch loop manually by calling the internal methods
+    # in the same order as _watch_file. With the fix, save runs first because
+    # _save_scheduled is True — so _check_file is never called.
+    reload_called = False
+    original_reload = file_api._reload_content_inplace
+
+    async def tracking_reload(jydoc):
+        nonlocal reload_called
+        reload_called = True
+        await original_reload(jydoc)
+
+    file_api._reload_content_inplace = tracking_reload
+
+    # Simulate one iteration of _watch_file (the fixed version)
+    if file_api._save_scheduled:
+        await file_api.save(jupyter_ydoc)
+    else:
+        await file_api._check_file(jupyter_ydoc)
+
+    # The save should have run (not the check), so no reload happened
+    assert not reload_called, (
+        "_reload_content_inplace was called — the OOB check ran before the "
+        "save, which means the stale _last_modified triggered a spurious reload"
+    )
+    assert not file_api._save_scheduled
+    # After saving, _last_modified should be updated (not stale)
+    assert file_api._last_modified != stale_time
+
+    # Verify the modified content was persisted
+    with open(mock_plaintext_file) as f:
+        assert f.read() == "modified content"
+
+    file_api.stop()
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_oob_check_still_runs_when_no_save_pending(
+    plaintext_file_api: YRoomFileAPI,
+    empty_yunicode: YUnicode,
+    mock_plaintext_file: str,
+):
+    """Verify that real out-of-band changes are still detected and applied when
+    no save is pending.
+
+    Background:
+        The fix skips _check_file() when _save_scheduled is True. This test
+        ensures that when NO save is pending (the common idle case), OOB
+        detection still works — i.e. if an external process (terminal editor,
+        git checkout, etc.) modifies the file, the YDoc picks up the change.
+
+    What this test does:
+        - Loads a file into the YDoc
+        - Writes new content directly to the file on disk (simulating an
+          external edit)
+        - Confirms no save is pending
+        - Calls _check_file() (the path taken when _save_scheduled is False)
+        - Asserts the YDoc content was updated to match the external edit
+    """
+    file_api = plaintext_file_api
+    jupyter_ydoc = empty_yunicode
+    file_api.load_content_into(jupyter_ydoc)
+    await file_api.until_content_loaded
+
+    # Externally modify the file to create a real OOB change
+    with open(mock_plaintext_file, "w") as f:
+        f.write("external edit")
+
+    # No save is pending
+    assert not file_api._save_scheduled
+
+    # Simulate one iteration: should run _check_file (not save)
+    # _check_file will detect the mtime mismatch and reload
+    await file_api._check_file(jupyter_ydoc)
+
+    # The content should have been reloaded from disk
+    assert jupyter_ydoc.source == "external edit"
+
     file_api.stop()
 


### PR DESCRIPTION
After a room is GC'd and re-initialized, running a cell triggers an infinite cycle: the output processor clears cell outputs in the YDoc, which schedules a save, but the file watcher's out-of-band check fires first and detects a stale mtime mismatch (left over from the GC'd session). This triggers an in-place reload that overwrites the cleared outputs, which triggers another save, which triggers another mismatch detection, and so on. The user sees outputs never appearing, the cell timer stuck running, and cell content getting clobbered.

## Observed behavior

From server logs on an affected notebook:

**Room GC'd after inactivity:**
```
[I 2026-05-07 15:27:47.005 ServerDocsApp] Stopping YRoom 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056'.
[I 2026-05-07 15:27:47.005 ServerDocsApp] Stopped YRoom 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056'.
[I 2026-05-07 15:27:47.023 ServerDocsApp] Deleted YRoom 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056'.
```

**Room re-initialized ~1hr later when user reopens notebook, immediately restarted by session_manager reconnecting the kernel:**
```
[I 2026-05-07 16:32:54.908 ServerDocsApp] Initializing room 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056'.
[I 2026-05-07 16:32:54.912 ServerDocsApp] Loading content for room ID 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056', found at path: 'Untitled5.ipynb'.
[I 2026-05-07 16:32:54.949 ServerDocsApp] Loaded content for room ID 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056'.
[E 2026-05-07 16:32:55.234 ServerDocsApp] Activity in empty YRoom 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056' from 'restart()'.
[I 2026-05-07 16:32:55.235 ServerDocsApp] Restarted FileAPI for room 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056'.
[I 2026-05-07 16:32:55.235 ServerDocsApp] Restarted YRoom 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056'.
```

**User runs a cell — output processor clears outputs, file watcher detects stale mtime mismatch, reloads file in-place (overwriting the YDoc mutation):**
```
[E 2026-05-07 16:33:33.206 ServerDocsApp] Activity in empty YRoom '...' from '_on_jupyter_ydoc_update()'.
{"message": "Cleared outputs for self._file_id='1c779c04-f50d-41ec-b034-b6013ba21056', cell_index=0", ...}
[W 2026-05-07 16:33:33.377 ServerDocsApp] Out-of-band file change detected. Room ID: 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056', Last detected change: '2026-05-07 15:27:47.017984+00:00', Most recent change: '2026-05-07 16:33:33.371336+00:00'.
[I 2026-05-07 16:33:33.377 ServerDocsApp] Reloading content in-place for room ID 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056' at path: 'Untitled5.ipynb'.
[I 2026-05-07 16:33:33.387 ServerDocsApp] Reloaded content in-place for room ID 'json:notebook:1c779c04-f50d-41ec-b034-b6013ba21056'.
```

Note `Last detected change: '2026-05-07 15:27:47.017984+00:00'` — the stale timestamp from when the room was GC'd over an hour earlier.

**Cascade repeats every ~500ms — clear, mismatch, reload, clear, mismatch, reload...:**
```
{"message": "Cleared outputs for self._file_id='1c779c04-f50d-41ec-b034-b6013ba21056', cell_index=0", ...}
[W 2026-05-07 16:33:37.952 ServerDocsApp] Out-of-band file change detected. ...
[I 2026-05-07 16:33:37.952 ServerDocsApp] Reloading content in-place ...
[I 2026-05-07 16:33:37.959 ServerDocsApp] Reloaded content in-place ...

{"message": "Cleared outputs for self._file_id='1c779c04-f50d-41ec-b034-b6013ba21056', cell_index=0", ...}
[W 2026-05-07 16:33:57.649 ServerDocsApp] Out-of-band file change detected. ...
[I 2026-05-07 16:33:57.649 ServerDocsApp] Reloading content in-place ...

{"message": "Cleared outputs for self._file_id='1c779c04-f50d-41ec-b034-b6013ba21056', cell_index=0", ...}
[W 2026-05-07 16:34:29.441 ServerDocsApp] Out-of-band file change detected. ...
[I 2026-05-07 16:34:29.441 ServerDocsApp] Reloading content in-place ...

{"message": "Cleared outputs for self._file_id='1c779c04-f50d-41ec-b034-b6013ba21056', cell_index=0", ...}
[W 2026-05-07 16:34:31.489 ServerDocsApp] Out-of-band file change detected. ...
[I 2026-05-07 16:34:31.489 ServerDocsApp] Reloading content in-place ...
```

Cell 0 cleared 5 times in one minute. Cell 3 cleared 4 times between 16:34:57 and 16:35:21.

**Client gets 404 — output wiped before it could be fetched:**
```
{"message": "404 GET /api/outputs/1c779c04-f50d-41ec-b034-b6013ba21056/527496bf-4ab5-4f12-903a-f4bdd984f91c/0.output?1778171646220 (...) 2.11ms", ...}
```

**User interrupts kernel (gives up):**
```
{"message": "Kernel interrupted: d1270be6-4ce9-4007-8ebb-6d0a4b2581e2", ...}  @ 16:33:42
{"message": "Kernel interrupted: d1270be6-4ce9-4007-8ebb-6d0a4b2581e2", ...}  @ 16:34:21
```

## Root cause

When `restart()` calls `stop(restarting=True)`, it creates a fire-and-forget save task that writes the OLD YDoc to disk. In cloud environments with async ContentsManagers, this save can complete after the new `_load_content()` has already set `_last_modified` from the file's mtime at read time. When the delayed save finishes, the file mtime is now newer than `_last_modified`, creating the initial mismatch that seeds the cascade.

## Fix

Two changes that address the root cause and harden the design:

**1. Skip save task in `stop()` when restarting** (root cause fix)

Content will be reloaded from disk immediately after restart, so saving old state is unnecessary and creates the timestamp mismatch that triggers the cascade.

**2. Save before OOB check in `_watch_file`** (design hardening)

The old loop ordering (check then save) means that if `_last_modified` ever drifts from the file mtime while a save is pending — for any reason (clock skew, eventual consistency, concurrent writes) — you get a cascade. The new ordering saves first when `_save_scheduled=True`, updates `_last_modified`, and defers the OOB check to the next quiet tick. This makes the system self-healing against any source of mtime drift.

Fix #2 without #1 would still write stale content during restarts. Fix #1 without #2 would still be vulnerable to filesystem timing issues in distributed environments. Together they eliminate both the specific trigger and the class of related failures.