### PR TITLE
Require `jupyter-collaboration-ui<2.4.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "jupyter-collaboration-ui>=2.0.2,<3",
+    # 2.4.0 activates collaboration plugins that expect the default
+    # docprovider extension, which server-documents replaces.
+    "jupyter-collaboration-ui>=2.0.2,<2.4.0",
     "jupyter_server>=2.4.0,<3",
     "jupyter_server_fileid>=0.9.0,<0.10.0",
     "jupyter_ydoc>=3.0.0,<4.0.0",


### PR DESCRIPTION
Fixes #235

## Summary
- Cap `jupyter-collaboration-ui` below 2.4.0.
- `jupyter-collaboration-ui` 2.4.0 was uploaded on 2026-05-11 and brings collaboration frontend plugins that expect the default docprovider extension.
- This project replaces/disables the default docprovider extension, so keeping the dependency on the last known 2.3.x line avoids the browser-check activation failure.

## Tests
- `uv pip install --python .venv\\Scripts\\python.exe -e ".[test]"` resolved `jupyter-collaboration-ui 2.3.0`
- `.venv\\Scripts\\python.exe -m jupyterlab.browser_check`
- `.venv\\Scripts\\python.exe -m pytest -q` -> 196 passed

## Notes
- Kept the change limited to the dependency constraint in `pyproject.toml`.