### PR TITLE
Bypass kernel output handling if no YRooms attached

### DIFF
--- a/jupyter_server_documents/kernels/kernel_client.py
+++ b/jupyter_server_documents/kernels/kernel_client.py
@@ -214,7 +214,11 @@ class DocumentAwareKernelClient(AsyncKernelClient):
         when appropriate. Then, it routes the message
         to all listeners.
         """
-        if channel_name in ('iopub', 'shell'):
+        # Only intercept shell & iopub messages if the kernel has YRooms
+        # (i.e. YNotebooks) attached.
+        # Otherwise, if there are no YRooms (e.g. kernel consoles or Voila
+        # dashboards), skip this branch and forward the message to listeners.
+        if channel_name in ('iopub', 'shell') and self._yrooms:
             msg = await self.handle_document_related_message(msg)
             # If msg has been cleared by the handler, escape this method.
             if msg is None:
@@ -303,12 +307,8 @@ class DocumentAwareKernelClient(AsyncKernelClient):
 
             case "stream" | "display_data" | "execute_result" | "error" | "update_display_data" | "clear_output":
                 if cell_id:
-                    # If no YRooms are registered (e.g. kernel consoles), let
-                    # the message pass through to listeners unmodified.
-                    if not self._yrooms:
-                        pass
                     # Process specific output messages through an optional processor
-                    elif self.output_processor:
+                    if self.output_processor:
                         content = self.session.unpack(dmsg["content"])
                         self.output_processor.process_output(dmsg['msg_type'], cell_id, content)
                         

--- a/jupyter_server_documents/kernels/kernel_client.py
+++ b/jupyter_server_documents/kernels/kernel_client.py
@@ -1,7 +1,6 @@
 """
 A new Kernel client that is aware of ydocuments.
 """
-import anyio
 import asyncio
 import json
 import typing as t
@@ -60,19 +59,12 @@ class DocumentAwareKernelClient(AsyncKernelClient):
         return self.output_process_class(parent=self, config=self.config)
 
     async def start_listening(self):
-        """Start listening to messages coming from the kernel.
-        
-        Use anyio to setup a task group for listening.
-        """
-        # Wrap a taskgroup so that it can be backgrounded.
+        """Start listening to messages coming from the kernel."""
         async def _listening():
-            async with anyio.create_task_group() as tg:
+            async with asyncio.TaskGroup() as tg:
                 for channel_name in ["shell", "control", "stdin", "iopub"]:
-                    tg.start_soon(
-                        self._listen_for_messages, channel_name
-                    )
+                    tg.create_task(self._listen_for_messages(channel_name))
 
-        # Background this task.
         self._listening_task = asyncio.create_task(_listening())
 
     async def stop_listening(self):
@@ -191,20 +183,14 @@ class DocumentAwareKernelClient(AsyncKernelClient):
         """
         Sends message to all registered listeners.
         """
-        async with anyio.create_task_group() as tg:
-            # Broadcast the message to all listeners.
-            for listener in self._listeners:
-                async def _wrap_listener(listener_to_wrap, channel_name, msg):
-                    """
-                    Wrap the listener to ensure its async and 
-                    logs (instead of raises) exceptions.
-                    """
-                    try:
-                        await ensure_async(listener_to_wrap(channel_name, msg))
-                    except Exception as err:
-                        self.log.error(err)
+        for listener in self._listeners:
+            async def _notify(listener_to_call, channel_name, msg):
+                try:
+                    await ensure_async(listener_to_call(channel_name, msg))
+                except Exception:
+                    self.log.exception("Error in kernel message listener")
 
-                tg.start_soon(_wrap_listener, listener, channel_name, msg)    
+            asyncio.create_task(_notify(listener, channel_name, msg))    
 
     async def handle_outgoing_message(self, channel_name: str, msg: list[bytes]):
         """This is the main method that consumes every

--- a/jupyter_server_documents/tests/kernels/test_kernel_client.py
+++ b/jupyter_server_documents/tests/kernels/test_kernel_client.py
@@ -151,10 +151,11 @@ class TestConsoleOutputPassthrough:
         # No yrooms registered (console scenario)
         assert len(client._yrooms) == 0
 
-        result = await client.handle_document_related_message(msg_list)
+        with patch.object(client, 'send_message_to_listeners') as mock_send:
+            await client.handle_outgoing_message("iopub", msg_list)
 
-        # Message should pass through (not None)
-        assert result is not None
+        # Message should be forwarded to listeners (not suppressed)
+        mock_send.assert_called_once_with("iopub", msg_list)
 
     @pytest.mark.asyncio
     async def test_output_suppressed_with_yrooms(self):

--- a/jupyter_server_documents/tests/test_output_processor.py
+++ b/jupyter_server_documents/tests/test_output_processor.py
@@ -196,7 +196,7 @@ async def test_output_task_update_display_after_clear_no_index_error():
         assert len(cell["outputs"]) == 1
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_clear_output_task_does_not_clear_disk():
     """clear_output from kernel should only clear YDoc, not disk."""
     fake_nb = FakeNotebook("cell-1")
@@ -210,7 +210,7 @@ async def test_clear_output_task_does_not_clear_disk():
     mock_outputs_mgr.clear.assert_not_called()
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_clear_cell_outputs_does_clear_disk():
     """clear_cell_outputs (execute_request) should clear both YDoc and disk."""
     fake_nb = FakeNotebook("cell-1")
@@ -225,7 +225,7 @@ async def test_clear_cell_outputs_does_clear_disk():
     mock_outputs_mgr.clear.assert_called_once_with(file_id="file-1", cell_id="cell-1")
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_clear_output_does_not_wipe_subsequent_output():
     """Simulate one progress bar iteration: output → clear → new output."""
     fake_nb = FakeNotebook("cell-1")
@@ -247,7 +247,7 @@ async def test_clear_output_does_not_wipe_subsequent_output():
     mock_outputs_mgr.clear.assert_not_called()
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_clear_output_wait_defers_to_next_output():
     """clear_output(wait=True) should defer clearing until next output."""
     fake_nb = FakeNotebook("cell-1")


### PR DESCRIPTION
## Description


- Bypass kernel output handling if no YRooms are attached (e.g. kernel consoles or Voila dashboards) - this should be a more general and reliable approach than the one introduced in #230.
- Removed remaining references to `anyio`