### PR TITLE
fix: restore kernel.last_activity updates for idle monitoring

### DIFF
--- a/jupyter_server_documents/kernels/kernel_manager.py
+++ b/jupyter_server_documents/kernels/kernel_manager.py
@@ -105,6 +105,7 @@ class NextGenKernelManager(AsyncKernelManager):
         # Track execution state by watching all messages that come through
         # the kernel client.
         self.main_client.add_listener(self.execution_state_listener)
+        self.main_client.add_listener(self._record_activity)
         self.set_state(LifecycleStates.CONNECTING, ExecutionStates.STARTING)
         await self.broadcast_state()
         self.main_client.start_channels()
@@ -173,3 +174,9 @@ class NextGenKernelManager(AsyncKernelManager):
                 parent_channel = message_data.get("channel")
                 if parent_channel and parent_channel == "shell":
                     self.set_state(LifecycleStates.CONNECTED, ExecutionStates(execution_state))
+
+    def _record_activity(self, channel_name: str, msg: list[bytes]):
+        """Update last_activity on IOPub messages for idle monitoring."""
+        if channel_name == "iopub":
+            from jupyter_client.utils import utcnow
+            self.last_activity = utcnow()


### PR DESCRIPTION
NextGenMappingKernelManager.start_watching_activity() was a no-op, which prevented kernel.last_activity from being updated on IOPub messages. This broke external idle monitoring systems (e.g. SageMaker's idle shutdown extension) that read last_activity via the Jupyter session API.

Instead of opening a second ZMQ IOPub socket (which conflicts with JSD's single-client architecture), we attach a lightweight listener callback to the kernel's main_client that updates last_activity on every IOPub message.

Fixes: kernel.last_activity frozen at kernel start time, causing premature idle shutdown during active cell execution.


Before
<img width="844" height="599" alt="image" src="https://github.com/user-attachments/assets/7e49f12c-d3e2-4ee7-b286-5e1d0eb44cfd" />


After
<img width="844" height="599" alt="image" src="https://github.com/user-attachments/assets/71ad9a11-3106-4461-82c3-84f48b10ad4d" />


without JSD
<img width="844" height="599" alt="image" src="https://github.com/user-attachments/assets/3055550f-f524-49c7-ac6e-162aae6beedc" />
