### PR TITLE
Support jupyter-collaboration-ui 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,8 @@
         "schemaDir": "schema",
         "disabledExtensions": [
             "@jupyterlab/codemirror-extension:binding",
-            "@jupyter/docprovider-extension"
+            "@jupyter/docprovider-extension",
+            "@jupyter/collaboration-extension:rtcGlobalAwareness"
         ],
         "sharedPackages": {
             "@jupyter/chat": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     # 2.4.0 activates collaboration plugins that expect the default
     # docprovider extension, which server-documents replaces.
-    "jupyter-collaboration-ui>=2.0.2,<2.4.0",
+    "jupyter-collaboration-ui>=2.0.2,<3",
     "jupyter_server>=2.4.0,<3",
     "jupyter_server_fileid>=0.9.0,<0.10.0",
     "jupyter_ydoc>=3.0.0,<4.0.0",


### PR DESCRIPTION

`jupyter-collaboration-ui==2.4.0` ships a new `rtcGlobalAwareness` plugin that requires `IAwarenessProviderFactory`. We don't use their plugin — we provide our own `IGlobalAwareness` via `rtcGlobalAwarenessPlugin`. Disabling theirs eliminates the unsatisfied token requirement.

## Changes

- Disable `@jupyter/collaboration-extension:rtcGlobalAwareness` in `package.json`
- Revert the `<2.4.0` version cap to `<3` in `pyproject.toml`

Fixes #237