### PR TITLE
fix: remove server-side YDoc source clearing to prevent data loss

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -638,26 +638,6 @@ class YRoom(LoggingConfigurable):
         elif sync_message_subtype == YSyncMessageSubtype.SYNC_UPDATE:
             self.handle_sync_update(client_id, message)
 
-    @staticmethod
-    def _decode_state_vector(sv: bytes) -> dict[int, int]:
-        d = pycrdt.Decoder(sv)
-        return {d.read_var_uint(): d.read_var_uint() for _ in range(d.read_var_uint())}
-
-    def _has_divergent_history(self, message_payload: bytes, server_sv_bytes: bytes) -> bool:
-        """Returns True if the client's state vector contains client IDs
-        unknown to the server, indicating a stale client from a previous
-        session."""
-        d = pycrdt.Decoder(message_payload)
-        d.read_var_uint()  # skip subtype
-        sv_bytes = d.read_message()
-        if sv_bytes is None:
-            return False
-        client_sv = self._decode_state_vector(sv_bytes)
-        if not client_sv:
-            return False
-        server_sv = self._decode_state_vector(server_sv_bytes)
-        return bool(set(client_sv) - set(server_sv))
-
     async def handle_sync(self, client_id: str, ss1_message: bytes) -> None:
         """
         Handles the bidirectional sync handshake initiated upon receiving a
@@ -667,12 +647,6 @@ class YRoom(LoggingConfigurable):
         2. Sends a SyncStep1 message requesting client side updates,
         3. Awaits the client's SyncStep2 reply (up to 5s timeout),
         4. Applies the client's SyncStep2 reply.
-
-        If the client has divergent history (stale client from a previous
-        session), the server clears the YDoc source before the handshake,
-        suppresses broadcasts and saves, then restores the source after the
-        handshake completes. This prevents content duplication caused by merging
-        two YDocs with the same content but different CRDT histories.
         """
         # Mark client as desynced
         self.clients.mark_desynced(client_id)
@@ -684,32 +658,6 @@ class YRoom(LoggingConfigurable):
         # which triggers a pycrdt offset encoding bug (#197) where
         # incremental Text updates after multi-byte characters crash JS yjs.
         pre_sync_sv = self._ydoc.get_state()
-
-        # Check if client has divergent history
-        ss1_payload = ss1_message[1:]
-        divergent = self._has_divergent_history(ss1_payload, pre_sync_sv)
-
-        # If divergent, pause update broadcasts and file saves then clear the
-        # YDoc source to prevent content duplication.
-        saved_source = None
-        if divergent and self._jupyter_ydoc is not None:
-            self.log.warning(
-                "Client '%s' has divergent history in room '%s'. Clearing YDoc source before handshake.",
-                client_id,
-                self.room_id
-            )
-            self.update_channel.pause()
-            if self.file_api is not None:
-                self.file_api._reloading_content = True
-            # reset JupyterYDoc source
-            saved_source = self._jupyter_ydoc.source
-            _, file_type, _ = self.room_id.split(":")
-            JupyterYDocClass = cast(
-                type[YBaseDoc],
-                jupyter_ydoc_classes.get(file_type, jupyter_ydoc_classes["file"])
-            )
-            empty_jupyter_ydoc = JupyterYDocClass()
-            self._jupyter_ydoc.source = empty_jupyter_ydoc.source
 
         # Initialize future that resolves when an SS2 reply is received.
         loop = asyncio.get_running_loop()
@@ -736,16 +684,9 @@ class YRoom(LoggingConfigurable):
             self.log.exception("Exception raised during sync handshake with client '%s' in room '%s':", client_id, self.room_id)
             handshake_failed = True
 
-        # Restore the YDoc source, flush the update_channel with a batched
-        # catchup diff, and resume saving, regardless of whether the handshake
-        # succeeded.
-        if saved_source is not None and self._jupyter_ydoc is not None:
-            self._jupyter_ydoc.source = saved_source
-            self.log.info("Restored YDoc source.")
+        # Flush the update_channel with a batched catchup diff.
         self.update_channel.resume(pre_sync_sv=pre_sync_sv)
-        if self.file_api is not None:
-            self.file_api._reloading_content = False
-        
+
         # Clear instance state
         self._pending_ss2_future = None
         self._pending_ss2_client_id = None

--- a/jupyter_server_documents/rooms/yroom_file_api.py
+++ b/jupyter_server_documents/rooms/yroom_file_api.py
@@ -605,6 +605,11 @@ class YRoomFileAPI(LoggingConfigurable):
         start_time = time.perf_counter()
 
         try:
+            # Return immediately if a content reload is in progress to prevent
+            # writing empty/intermediate content to disk.
+            if self._reloading_content:
+                return
+
             # Return immediately if the content manager has marked this file as non-writable
             if not self._is_writable:
                 return

--- a/jupyter_server_documents/tests/test_yroom_sync.py
+++ b/jupyter_server_documents/tests/test_yroom_sync.py
@@ -5,11 +5,9 @@ These tests use a FakeWebSocket client that simulates the client side of the
 Yjs sync protocol against a real YRoom instance. They verify:
 
 1. Normal sync handshake completes successfully.
-2. Divergent client detection works correctly.
-3. Divergent client handshake resolves content duplication.
-4. Timeout fires if client never sends SS2.
-5. Update buffer pauses/resumes correctly during divergent handshake.
-6. No data loss when mutations occur during the sync handshake.
+2. Divergent clients complete handshake without data loss.
+3. Timeout fires if client never sends SS2.
+4. Multiple clients sync without data loss.
 """
 
 from __future__ import annotations
@@ -135,25 +133,16 @@ class TestNormalSync:
 
 
 class TestDivergentSync:
-    """Tests for divergent client sync (content deduplication)."""
+    """Tests for divergent client sync behavior.
+
+    Note: With the server-side source clearing removed (to prevent data loss),
+    divergent clients will cause content duplication. These tests verify the
+    handshake still completes and no data loss occurs.
+    """
 
     @pytest.mark.asyncio
-    async def test_divergent_client_detected(self, make_yroom: MakeYRoom):
-        """A client with unknown client IDs should be detected as divergent."""
-        yroom = await make_yroom()
-        jupyter_ydoc = await yroom.get_jupyter_ydoc()
-        jupyter_ydoc.source = "hello world"
-
-        # Client has same content but different CRDT history
-        ws = FakeWebSocket()
-        ws.doc["source"] += "hello world"
-
-        ss1 = ws.build_ss1()
-        assert yroom._has_divergent_history(ss1[1:], yroom._ydoc.get_state())
-
-    @pytest.mark.asyncio
-    async def test_divergent_client_no_duplication(self, make_yroom: MakeYRoom):
-        """After a divergent handshake, content should not be duplicated."""
+    async def test_divergent_client_completes_handshake(self, make_yroom: MakeYRoom):
+        """A divergent client should complete the handshake without error."""
         yroom = await make_yroom()
         jupyter_ydoc = await yroom.get_jupyter_ydoc()
         jupyter_ydoc.source = "hello world"
@@ -172,13 +161,13 @@ class TestDivergentSync:
         yroom.add_message(client_id, ss2_reply)
         await asyncio.sleep(0.1)
 
-        # No duplication on either side
-        assert jupyter_ydoc.source == "hello world"
-        assert ws.source == "hello world"
+        # Client should be synced (handshake completed)
+        client = yroom.clients.get(client_id)
+        assert client.synced
 
     @pytest.mark.asyncio
-    async def test_divergent_client_no_save_during_handshake(self, make_yroom: MakeYRoom):
-        """File saves should be suppressed during the divergent handshake."""
+    async def test_divergent_client_no_data_loss(self, make_yroom: MakeYRoom):
+        """A divergent client handshake must never cause data loss on the server."""
         yroom = await make_yroom()
         jupyter_ydoc = await yroom.get_jupyter_ydoc()
         jupyter_ydoc.source = "hello world"
@@ -191,40 +180,13 @@ class TestDivergentSync:
         yroom.add_message(client_id, ss1)
         await asyncio.sleep(0.1)
 
-        # During handshake, saves should be suppressed
-        assert yroom.file_api._reloading_content is True
-
         ss2_reply = ws.process_server_messages()
+        assert ss2_reply is not None
         yroom.add_message(client_id, ss2_reply)
         await asyncio.sleep(0.1)
 
-        # After handshake, saves should be re-enabled
-        assert yroom.file_api._reloading_content is False
-
-    @pytest.mark.asyncio
-    async def test_update_channel_paused_during_divergent_handshake(self, make_yroom: MakeYRoom):
-        """The update buffer should be paused during a divergent handshake."""
-        yroom = await make_yroom()
-        jupyter_ydoc = await yroom.get_jupyter_ydoc()
-        jupyter_ydoc.source = "hello world"
-
-        ws = FakeWebSocket()
-        ws.doc["source"] += "hello world"
-        client_id = yroom.clients.add(ws)
-
-        ss1 = ws.build_ss1()
-        yroom.add_message(client_id, ss1)
-        await asyncio.sleep(0.1)
-
-        # Buffer should be paused during handshake
-        assert yroom.update_channel._paused is True
-
-        ss2_reply = ws.process_server_messages()
-        yroom.add_message(client_id, ss2_reply)
-        await asyncio.sleep(0.1)
-
-        # Buffer should be unpaused after handshake
-        assert yroom.update_channel._paused is False
+        # Server content must contain the original text (may be duplicated, but never empty)
+        assert "hello world" in jupyter_ydoc.source
 
 
 class TestSyncTimeout:
@@ -233,7 +195,7 @@ class TestSyncTimeout:
     @pytest.mark.asyncio
     async def test_timeout_when_ss2_never_arrives(self, make_yroom: MakeYRoom):
         """If the client never sends SS2, the handshake should time out and
-        the source should be restored."""
+        the client should be disconnected. Content must be preserved."""
         yroom = await make_yroom()
         jupyter_ydoc = await yroom.get_jupyter_ydoc()
         jupyter_ydoc.source = "hello world"
@@ -248,12 +210,10 @@ class TestSyncTimeout:
         # Wait for timeout (5s + buffer)
         await asyncio.sleep(6)
 
-        # Source should be restored
+        # Content must be preserved (no data loss)
         assert jupyter_ydoc.source == "hello world"
-        # Saves should be re-enabled
-        assert yroom.file_api._reloading_content is False
-        # Buffer should be unpaused
-        assert yroom.update_channel._paused is False
+        # Client should be disconnected
+        assert ws.closed
 
 
 class TestMultipleClients:
@@ -261,8 +221,8 @@ class TestMultipleClients:
 
     @pytest.mark.asyncio
     async def test_two_divergent_clients_sequential(self, make_yroom: MakeYRoom):
-        """Two divergent clients syncing sequentially should both get correct
-        content."""
+        """Two divergent clients syncing sequentially should both complete
+        handshake and not cause data loss."""
         yroom = await make_yroom()
         jupyter_ydoc = await yroom.get_jupyter_ydoc()
         jupyter_ydoc.source = "hello world"
@@ -281,12 +241,13 @@ class TestMultipleClients:
             yroom.add_message(client_id, ss2_reply)
             await asyncio.sleep(0.1)
 
-            assert jupyter_ydoc.source == "hello world"
-            assert ws.source == "hello world"
+            # Content must never be empty (data loss)
+            assert "hello world" in jupyter_ydoc.source
 
     @pytest.mark.asyncio
     async def test_fresh_then_divergent_client(self, make_yroom: MakeYRoom):
-        """A fresh client followed by a divergent client should both work."""
+        """A fresh client followed by a divergent client should both complete
+        handshake without data loss."""
         yroom = await make_yroom()
         jupyter_ydoc = await yroom.get_jupyter_ydoc()
         jupyter_ydoc.source = "hello world"
@@ -311,8 +272,8 @@ class TestMultipleClients:
         yroom.add_message(cid2, ss2)
         await asyncio.sleep(0.1)
 
-        assert jupyter_ydoc.source == "hello world"
-        assert ws2.source == "hello world"
+        # No data loss — content must contain original text
+        assert "hello world" in jupyter_ydoc.source
 
 
 async def _complete_handshake(yroom: YRoom, ws: FakeWebSocket) -> str:


### PR DESCRIPTION
The divergent-client handshake introduced in #215 temporarily clears the YDoc source on the server during sync. If a save fires during that window (graceful shutdown or periodic _watch_file tick), it writes empty content to disk — causing data loss (V2245873628).

This commit removes the server-side source clearing entirely. Divergent clients (stale reconnections after YRoom GC) will see content duplication, which is the pre-#215 behavior — a cosmetic issue, not destructive.

Also adds a defensive guard in save() to skip writes when _reloading_content is True, as defense-in-depth against any future re-introduction of source-clearing logic.