### PR TITLE
[Bug] Fix execution indicator showing 'unknown' on notebook reopen mid-execution

### DIFF
--- a/jupyter_server_documents/nudge.py
+++ b/jupyter_server_documents/nudge.py
@@ -1,0 +1,152 @@
+"""
+Kernel state probing via dual-channel kernel_info_request.
+
+The nudge determines whether a running kernel is idle or busy by sending
+kernel_info_request on both the shell and control channels simultaneously.
+Control bypasses the execution queue and always replies; shell is blocked
+while a cell is executing.
+
+  control + shell reply  → "idle"
+  control reply only     → "busy"
+  no reply within timeout → "unknown"
+
+Also listens for iopub_welcome (JEP #65 / ipykernel >= 7.2.0), which arrives
+~5 ms after connection on XPUB-capable kernels and allows early termination
+of the wait before the shell_window expires.
+
+This follows the same approach used in jupyter_server for detecting kernel
+state on reconnect, generalised so it can be called from any context that
+has an AsyncKernelClient — not just the WebSocket handler.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import typing as t
+
+
+async def nudge_kernel(
+    client,
+    *,
+    kernel_info_timeout: float = 5.0,
+    kernel_info_reply_window: float = 0.2,
+    pending_tasks: t.Set[asyncio.Task] | None = None,
+) -> str:
+    """Probe a kernel's busy/idle state and return one of "idle", "busy", or "unknown".
+
+    Args:
+        client: A started AsyncKernelClient (channels must already be running).
+        kernel_info_timeout: Overall deadline in seconds.  Increase for
+            high-latency or slow-starting remote kernels.
+        kernel_info_reply_window: After the control channel replies, how many
+            additional seconds to wait for the shell channel before declaring
+            the kernel busy.  Covers network jitter; idle kernels reply on
+            both channels nearly simultaneously (<50 ms locally).
+        pending_tasks: Optional set to register the internal probe tasks into.
+            The caller can cancel() all tasks in this set if it needs to abort
+            the probe early (e.g. WebSocket disconnect before nudge completes).
+            Tasks are removed from the set when the nudge finishes.
+    """
+    session = client.session
+    shell_socket = client.shell_channel.socket
+    control_socket = client.control_channel.socket
+    iopub_socket = client.iopub_channel.socket
+
+    session.send(shell_socket, session.msg("kernel_info_request"))
+    session.send(control_socket, session.msg("kernel_info_request"))
+
+    async def recv_reply(socket) -> bool:
+        try:
+            msg_list = await socket.recv_multipart()
+            _, fed = session.feed_identities(msg_list)
+            if len(fed) < 2:
+                return False
+            return json.loads(fed[1]).get("msg_type") == "kernel_info_reply"
+        except Exception:
+            return False
+
+    async def recv_welcome() -> bool:
+        """Listen for iopub_welcome with a short inner timeout.
+
+        Capped at kernel_info_reply_window so it doesn't delay probing on
+        kernels that don't support XPUB (ipykernel < 7.2.0).
+        """
+        try:
+            msg_list = await asyncio.wait_for(
+                iopub_socket.recv_multipart(),
+                timeout=kernel_info_reply_window,
+            )
+            _, fed = session.feed_identities(msg_list)
+            if len(fed) < 2:
+                return False
+            return json.loads(fed[1]).get("msg_type") == "iopub_welcome"
+        except (asyncio.TimeoutError, Exception):
+            return False
+
+    shell_task = asyncio.create_task(recv_reply(shell_socket))
+    control_task = asyncio.create_task(recv_reply(control_socket))
+    welcome_task = asyncio.create_task(recv_welcome())
+
+    tasks = {shell_task, control_task, welcome_task}
+    if pending_tasks is not None:
+        pending_tasks.update(tasks)
+
+    deadline = asyncio.get_event_loop().time() + kernel_info_timeout
+    active = set(tasks)
+
+    try:
+        while active:
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
+                break
+
+            done, active = await asyncio.wait(
+                active,
+                timeout=remaining,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            if not done:
+                break  # deadline reached
+
+            if control_task.done():
+                # Control replied — wait up to kernel_info_reply_window for
+                # shell to also reply (idle confirmation).
+                if not shell_task.done():
+                    shell_remaining = min(
+                        kernel_info_reply_window,
+                        deadline - asyncio.get_event_loop().time(),
+                    )
+                    if shell_remaining > 0:
+                        await asyncio.wait(
+                            [t for t in active if t is shell_task],
+                            timeout=shell_remaining,
+                        )
+                break
+
+            # Only welcome (or nothing useful) arrived — keep waiting.
+
+    finally:
+        for task in active:
+            task.cancel()
+        await asyncio.gather(*active, return_exceptions=True)
+        if pending_tasks is not None:
+            pending_tasks.difference_update(tasks)
+
+    def _result(task) -> bool:
+        if task.done() and not task.cancelled():
+            try:
+                return bool(task.result())
+            except Exception:
+                return False
+        return False
+
+    control_replied = _result(control_task)
+    shell_replied = _result(shell_task)
+
+    if control_replied and shell_replied:
+        return "idle"
+    elif control_replied:
+        return "busy"
+    else:
+        return "unknown"

--- a/jupyter_server_documents/tests/test_nudge.py
+++ b/jupyter_server_documents/tests/test_nudge.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for nudge_kernel().
+
+All tests use a mock AsyncKernelClient — no real kernel required.
+The mock's socket recv_multipart() is controlled via asyncio.Queue so
+tests can deterministically deliver (or withhold) replies.
+"""
+import asyncio
+import json
+import pytest
+from unittest.mock import MagicMock
+
+from jupyter_server_documents.nudge import nudge_kernel
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_msg(msg_type: str) -> list[bytes]:
+    """Build a minimal two-frame message list: [identity, header_json]."""
+    header = json.dumps({"msg_type": msg_type}).encode()
+    return [b"<identity>", header]
+
+
+class _MockSocket:
+    """Async socket whose recv_multipart() is driven by a Queue."""
+
+    def __init__(self):
+        self._queue: asyncio.Queue = asyncio.Queue()
+
+    def put(self, msg_list):
+        self._queue.put_nowait(msg_list)
+
+    async def recv_multipart(self):
+        return await self._queue.get()
+
+
+def _make_client(shell_socket, control_socket, iopub_socket):
+    session = MagicMock()
+    session.feed_identities.side_effect = lambda msg_list: ([], msg_list)
+    session.msg.return_value = {}
+    session.send.return_value = None
+
+    shell_channel = MagicMock()
+    shell_channel.socket = shell_socket
+    control_channel = MagicMock()
+    control_channel.socket = control_socket
+    iopub_channel = MagicMock()
+    iopub_channel.socket = iopub_socket
+
+    client = MagicMock()
+    client.session = session
+    client.shell_channel = shell_channel
+    client.control_channel = control_channel
+    client.iopub_channel = iopub_channel
+    return client
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+class TestNudgeKernel:
+
+    @pytest.mark.asyncio
+    async def test_idle_when_both_channels_reply(self):
+        """Both shell and control reply → idle."""
+        shell = _MockSocket()
+        control = _MockSocket()
+        iopub = _MockSocket()
+        client = _make_client(shell, control, iopub)
+
+        shell.put(_make_msg("kernel_info_reply"))
+        control.put(_make_msg("kernel_info_reply"))
+
+        result = await nudge_kernel(client, kernel_info_timeout=1.0, kernel_info_reply_window=0.2)
+        assert result == "idle"
+
+    @pytest.mark.asyncio
+    async def test_busy_when_only_control_replies(self):
+        """Control replies but shell stays silent → busy."""
+        shell = _MockSocket()
+        control = _MockSocket()
+        iopub = _MockSocket()
+        client = _make_client(shell, control, iopub)
+
+        control.put(_make_msg("kernel_info_reply"))
+        # shell never replies
+
+        result = await nudge_kernel(client, kernel_info_timeout=1.0, kernel_info_reply_window=0.05)
+        assert result == "busy"
+
+    @pytest.mark.asyncio
+    async def test_unknown_when_nothing_replies(self):
+        """No replies within timeout → unknown."""
+        shell = _MockSocket()
+        control = _MockSocket()
+        iopub = _MockSocket()
+        client = _make_client(shell, control, iopub)
+
+        # nothing put on any socket
+
+        result = await nudge_kernel(client, kernel_info_timeout=0.05, kernel_info_reply_window=0.02)
+        assert result == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_iopub_welcome_logged_but_does_not_change_result(self):
+        """iopub_welcome alone (no control reply) still returns unknown."""
+        shell = _MockSocket()
+        control = _MockSocket()
+        iopub = _MockSocket()
+        client = _make_client(shell, control, iopub)
+
+        iopub.put(_make_msg("iopub_welcome"))
+        # no control or shell reply
+
+        result = await nudge_kernel(client, kernel_info_timeout=0.1, kernel_info_reply_window=0.05)
+        assert result == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_idle_with_iopub_welcome_and_both_replies(self):
+        """iopub_welcome + both channel replies → idle."""
+        shell = _MockSocket()
+        control = _MockSocket()
+        iopub = _MockSocket()
+        client = _make_client(shell, control, iopub)
+
+        iopub.put(_make_msg("iopub_welcome"))
+        control.put(_make_msg("kernel_info_reply"))
+        shell.put(_make_msg("kernel_info_reply"))
+
+        result = await nudge_kernel(client, kernel_info_timeout=1.0, kernel_info_reply_window=0.2)
+        assert result == "idle"
+
+    @pytest.mark.asyncio
+    async def test_pending_tasks_cleared_after_completion(self):
+        """pending_tasks set is empty after nudge_kernel returns."""
+        shell = _MockSocket()
+        control = _MockSocket()
+        iopub = _MockSocket()
+        client = _make_client(shell, control, iopub)
+
+        control.put(_make_msg("kernel_info_reply"))
+        shell.put(_make_msg("kernel_info_reply"))
+
+        pending: set = set()
+        await nudge_kernel(client, kernel_info_timeout=1.0, kernel_info_reply_window=0.2, pending_tasks=pending)
+        assert len(pending) == 0
+
+    @pytest.mark.asyncio
+    async def test_pending_tasks_cancelled_on_external_cancel(self):
+        """Tasks registered in pending_tasks can be cancelled externally."""
+        shell = _MockSocket()
+        control = _MockSocket()
+        iopub = _MockSocket()
+        client = _make_client(shell, control, iopub)
+
+        # nothing on sockets — nudge would block for the full timeout
+        pending: set = set()
+
+        nudge_task = asyncio.create_task(
+            nudge_kernel(client, kernel_info_timeout=9999.0, kernel_info_reply_window=0.2, pending_tasks=pending)
+        )
+        await asyncio.sleep(0)  # let nudge start and register tasks
+
+        assert len(pending) > 0
+        for t in list(pending):
+            t.cancel()
+
+        # nudge_task itself will get CancelledError propagated via gather
+        nudge_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await nudge_task
+
+    @pytest.mark.asyncio
+    async def test_wrong_msg_type_not_counted_as_reply(self):
+        """Messages with unexpected msg_type are ignored."""
+        shell = _MockSocket()
+        control = _MockSocket()
+        iopub = _MockSocket()
+        client = _make_client(shell, control, iopub)
+
+        # deliver a wrong message type on control, then nothing on shell
+        control.put(_make_msg("execute_reply"))
+
+        result = await nudge_kernel(client, kernel_info_timeout=0.1, kernel_info_reply_window=0.05)
+        assert result == "unknown"

--- a/jupyter_server_documents/websocket_connection.py
+++ b/jupyter_server_documents/websocket_connection.py
@@ -6,7 +6,6 @@ tasks drive the receive loop via await socket.recv_multipart(). The client is
 always disposed in disconnect() regardless of how the connection ends.
 """
 import asyncio
-import json
 import typing as t
 
 import traitlets
@@ -16,6 +15,7 @@ from jupyter_server.services.kernels.connection.base import (
     deserialize_msg_from_ws_v1,
     serialize_msg_to_ws_v1,
 )
+from .nudge import nudge_kernel
 
 
 class KernelWebsocketConnection(BaseKernelWebsocketConnection):
@@ -62,7 +62,12 @@ class KernelWebsocketConnection(BaseKernelWebsocketConnection):
         # staying at "unknown" after a page refresh mid-execution.
         #
         # Also listens for iopub_welcome (JEP #65 / ipykernel >= 7.2.0).
-        state = await self._nudge_kernel()
+        state = await nudge_kernel(
+            self._client,
+            kernel_info_timeout=self.kernel_info_timeout,
+            kernel_info_reply_window=self.kernel_info_reply_window,
+            pending_tasks=self._nudge_tasks,
+        )
         self.log.debug("Kernel nudge result: %s", state)
 
         self._tasks = [
@@ -72,141 +77,6 @@ class KernelWebsocketConnection(BaseKernelWebsocketConnection):
 
         if state in ("busy", "idle") and self._client is not None:
             self._send_synthetic_status(state)
-
-    async def _nudge_kernel(self) -> str:
-        """Determine kernel busy/idle state using a two-path approach.
-
-        **Fast path — JEP #65 XPUB (ipykernel >= 7.2.0)**:
-        Listens on iopub for ``iopub_welcome``, sent by kernels that implement
-        the XPUB socket.  Receiving it confirms the IOPub subscription is live.
-
-        **Dual-channel shell + control nudge**:
-        Sends ``kernel_info_request`` on both channels simultaneously.
-        Control bypasses the execution queue; shell is blocked while executing.
-
-          control + shell reply  → "idle"
-          control reply only     → "busy"
-          no reply within timeout → "unknown"
-
-        Logic:
-        1. Race all three tasks with the overall ``kernel_info_timeout``.
-        2. As soon as any task completes, re-evaluate:
-           - If control replied: wait up to ``kernel_info_reply_window`` more
-             seconds for shell to also reply (idle confirmation), then return.
-           - If only welcome arrived: keep waiting for control/shell.
-           - If nothing arrived within ``kernel_info_timeout``: return "unknown".
-
-        This avoids the brittle hard-coded 200 ms cutoff: on a high-latency
-        kernel without XPUB support, welcome times out but we continue waiting
-        for control/shell up to the full ``kernel_info_timeout``.
-
-        Must be called BEFORE starting the listen tasks.
-        """
-        session = self._client.session
-        total_timeout = self.kernel_info_timeout
-        shell_window = self.kernel_info_reply_window
-
-        shell_socket = self._client.shell_channel.socket
-        control_socket = self._client.control_channel.socket
-        iopub_socket = self._client.iopub_channel.socket
-
-        session.send(shell_socket, session.msg("kernel_info_request"))
-        session.send(control_socket, session.msg("kernel_info_request"))
-
-        async def recv_reply(socket) -> bool:
-            try:
-                msg_list = await socket.recv_multipart()
-                _, fed = session.feed_identities(msg_list)
-                if len(fed) < 2:
-                    return False
-                return json.loads(fed[1]).get("msg_type") == "kernel_info_reply"
-            except Exception:
-                return False
-
-        async def recv_welcome() -> bool:
-            """Receive iopub_welcome with a short inner timeout.
-
-            The timeout is capped at shell_window so it doesn't delay the
-            probe on kernels that don't support XPUB (ipykernel < 7.2.0).
-            """
-            try:
-                msg_list = await asyncio.wait_for(
-                    iopub_socket.recv_multipart(),
-                    timeout=shell_window,
-                )
-                _, fed = session.feed_identities(msg_list)
-                if len(fed) < 2:
-                    return False
-                return json.loads(fed[1]).get("msg_type") == "iopub_welcome"
-            except (asyncio.TimeoutError, Exception):
-                return False
-
-        shell_task = asyncio.create_task(recv_reply(shell_socket))
-        control_task = asyncio.create_task(recv_reply(control_socket))
-        welcome_task = asyncio.create_task(recv_welcome())
-        # Register so disconnect() can cancel them if the WebSocket closes
-        # before the nudge finishes.
-        self._nudge_tasks = {shell_task, control_task, welcome_task}
-
-        deadline = asyncio.get_event_loop().time() + total_timeout
-        active = {shell_task, control_task, welcome_task}
-
-        while active:
-            remaining = deadline - asyncio.get_event_loop().time()
-            if remaining <= 0:
-                break
-
-            done, active = await asyncio.wait(
-                active,
-                timeout=remaining,
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-
-            if not done:
-                break  # deadline reached
-
-            if control_task.done():
-                # Control replied — wait up to shell_window for shell to also
-                # reply (idle confirmation), then we have enough information.
-                if not shell_task.done():
-                    shell_remaining = min(
-                        shell_window,
-                        deadline - asyncio.get_event_loop().time(),
-                    )
-                    if shell_remaining > 0:
-                        await asyncio.wait(
-                            [t for t in active if t is shell_task],
-                            timeout=shell_remaining,
-                        )
-                break  # we have a result; exit regardless
-
-            # Only welcome (or nothing useful) arrived so far — keep waiting.
-
-        for t in active:
-            t.cancel()
-        await asyncio.gather(*active, return_exceptions=True)
-        self._nudge_tasks.clear()
-
-        def result(task) -> bool:
-            if task.done() and not task.cancelled():
-                try:
-                    return bool(task.result())
-                except Exception:
-                    return False
-            return False
-
-        if result(welcome_task):
-            self.log.debug("Received iopub_welcome (XPUB kernel, protocol >= 5.4)")
-
-        control_replied = result(control_task)
-        shell_replied = result(shell_task)
-
-        if control_replied and shell_replied:
-            return "idle"
-        elif control_replied:
-            return "busy"
-        else:
-            return "unknown"
 
     def _send_synthetic_status(self, execution_state: str) -> None:
         """Send a synthetic status iopub message to the browser WebSocket."""
@@ -222,7 +92,7 @@ class KernelWebsocketConnection(BaseKernelWebsocketConnection):
 
     def disconnect(self) -> None:
         # Cancel nudge tasks first — they may still be running if the WebSocket
-        # closed before _nudge_kernel() completed.
+        # closed before nudge_kernel() completed.
         for task in self._nudge_tasks:
             task.cancel()
         self._nudge_tasks.clear()

--- a/jupyter_server_documents/websocket_connection.py
+++ b/jupyter_server_documents/websocket_connection.py
@@ -6,8 +6,10 @@ tasks drive the receive loop via await socket.recv_multipart(). The client is
 always disposed in disconnect() regardless of how the connection ends.
 """
 import asyncio
+import json
 import typing as t
 
+import traitlets
 from tornado.websocket import WebSocketClosedError
 from jupyter_server.services.kernels.connection.base import (
     BaseKernelWebsocketConnection,
@@ -21,19 +23,209 @@ class KernelWebsocketConnection(BaseKernelWebsocketConnection):
 
     kernel_ws_protocol = "v1.kernel.websocket.jupyter.org"
 
+    kernel_info_timeout = traitlets.Float(
+        5.0,
+        config=True,
+        help=(
+            "Seconds to wait for kernel_info_request replies during the "
+            "busy/idle nudge that runs on every new WebSocket connection. "
+            "Increase for high-latency or slow-starting remote kernels. "
+            "Only affects the 'unknown' / unreachable case; idle and busy "
+            "kernels are detected much faster."
+        ),
+    )
+
+    kernel_info_reply_window = traitlets.Float(
+        0.2,
+        config=True,
+        help=(
+            "After the control channel replies, how many additional seconds "
+            "to wait for the shell channel before declaring the kernel 'busy'. "
+            "An idle kernel replies on both channels nearly simultaneously "
+            "(<50 ms locally); this window only needs to cover network jitter."
+        ),
+    )
+
     _client: t.Any = None
     _tasks: t.List[asyncio.Task] = []
+    _nudge_tasks: t.Set[asyncio.Task] = set()
 
     async def connect(self) -> None:
         self._client = self.kernel_manager.client()
         self._client.load_connection_info(self.kernel_manager.get_connection_info())
         self._client.start_channels(hb=False)
+
+        # Probe kernel state on shell + control channels BEFORE starting the
+        # listen tasks so there is no race for messages.  The result is
+        # delivered to the browser as a synthetic status iopub message so the
+        # execution indicator immediately shows the correct state rather than
+        # staying at "unknown" after a page refresh mid-execution.
+        #
+        # Also listens for iopub_welcome (JEP #65 / ipykernel >= 7.2.0).
+        state = await self._nudge_kernel()
+        self.log.debug("Kernel nudge result: %s", state)
+
         self._tasks = [
             asyncio.create_task(self._listen(ch))
             for ch in ("shell", "control", "stdin", "iopub")
         ]
 
+        if state in ("busy", "idle") and self._client is not None:
+            self._send_synthetic_status(state)
+
+    async def _nudge_kernel(self) -> str:
+        """Determine kernel busy/idle state using a two-path approach.
+
+        **Fast path — JEP #65 XPUB (ipykernel >= 7.2.0)**:
+        Listens on iopub for ``iopub_welcome``, sent by kernels that implement
+        the XPUB socket.  Receiving it confirms the IOPub subscription is live.
+
+        **Dual-channel shell + control nudge**:
+        Sends ``kernel_info_request`` on both channels simultaneously.
+        Control bypasses the execution queue; shell is blocked while executing.
+
+          control + shell reply  → "idle"
+          control reply only     → "busy"
+          no reply within timeout → "unknown"
+
+        Logic:
+        1. Race all three tasks with the overall ``kernel_info_timeout``.
+        2. As soon as any task completes, re-evaluate:
+           - If control replied: wait up to ``kernel_info_reply_window`` more
+             seconds for shell to also reply (idle confirmation), then return.
+           - If only welcome arrived: keep waiting for control/shell.
+           - If nothing arrived within ``kernel_info_timeout``: return "unknown".
+
+        This avoids the brittle hard-coded 200 ms cutoff: on a high-latency
+        kernel without XPUB support, welcome times out but we continue waiting
+        for control/shell up to the full ``kernel_info_timeout``.
+
+        Must be called BEFORE starting the listen tasks.
+        """
+        session = self._client.session
+        total_timeout = self.kernel_info_timeout
+        shell_window = self.kernel_info_reply_window
+
+        shell_socket = self._client.shell_channel.socket
+        control_socket = self._client.control_channel.socket
+        iopub_socket = self._client.iopub_channel.socket
+
+        session.send(shell_socket, session.msg("kernel_info_request"))
+        session.send(control_socket, session.msg("kernel_info_request"))
+
+        async def recv_reply(socket) -> bool:
+            try:
+                msg_list = await socket.recv_multipart()
+                _, fed = session.feed_identities(msg_list)
+                if len(fed) < 2:
+                    return False
+                return json.loads(fed[1]).get("msg_type") == "kernel_info_reply"
+            except Exception:
+                return False
+
+        async def recv_welcome() -> bool:
+            """Receive iopub_welcome with a short inner timeout.
+
+            The timeout is capped at shell_window so it doesn't delay the
+            probe on kernels that don't support XPUB (ipykernel < 7.2.0).
+            """
+            try:
+                msg_list = await asyncio.wait_for(
+                    iopub_socket.recv_multipart(),
+                    timeout=shell_window,
+                )
+                _, fed = session.feed_identities(msg_list)
+                if len(fed) < 2:
+                    return False
+                return json.loads(fed[1]).get("msg_type") == "iopub_welcome"
+            except (asyncio.TimeoutError, Exception):
+                return False
+
+        shell_task = asyncio.create_task(recv_reply(shell_socket))
+        control_task = asyncio.create_task(recv_reply(control_socket))
+        welcome_task = asyncio.create_task(recv_welcome())
+        # Register so disconnect() can cancel them if the WebSocket closes
+        # before the nudge finishes.
+        self._nudge_tasks = {shell_task, control_task, welcome_task}
+
+        deadline = asyncio.get_event_loop().time() + total_timeout
+        active = {shell_task, control_task, welcome_task}
+
+        while active:
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
+                break
+
+            done, active = await asyncio.wait(
+                active,
+                timeout=remaining,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            if not done:
+                break  # deadline reached
+
+            if control_task.done():
+                # Control replied — wait up to shell_window for shell to also
+                # reply (idle confirmation), then we have enough information.
+                if not shell_task.done():
+                    shell_remaining = min(
+                        shell_window,
+                        deadline - asyncio.get_event_loop().time(),
+                    )
+                    if shell_remaining > 0:
+                        await asyncio.wait(
+                            [t for t in active if t is shell_task],
+                            timeout=shell_remaining,
+                        )
+                break  # we have a result; exit regardless
+
+            # Only welcome (or nothing useful) arrived so far — keep waiting.
+
+        for t in active:
+            t.cancel()
+        await asyncio.gather(*active, return_exceptions=True)
+        self._nudge_tasks.clear()
+
+        def result(task) -> bool:
+            if task.done() and not task.cancelled():
+                try:
+                    return bool(task.result())
+                except Exception:
+                    return False
+            return False
+
+        if result(welcome_task):
+            self.log.debug("Received iopub_welcome (XPUB kernel, protocol >= 5.4)")
+
+        control_replied = result(control_task)
+        shell_replied = result(shell_task)
+
+        if control_replied and shell_replied:
+            return "idle"
+        elif control_replied:
+            return "busy"
+        else:
+            return "unknown"
+
+    def _send_synthetic_status(self, execution_state: str) -> None:
+        """Send a synthetic status iopub message to the browser WebSocket."""
+        try:
+            msg = self._client.session.msg("status", {"execution_state": execution_state})
+            msg_list = self._client.session.serialize(msg, self._client.session.bsession)
+            _, fed = self._client.session.feed_identities(msg_list)
+            parts = fed[1:]  # strip signature frame
+            bin_msg = serialize_msg_to_ws_v1(parts, "iopub")
+            self.websocket_handler.write_message(bin_msg, binary=True)
+        except Exception as err:
+            self.log.warning("Could not send synthetic status:%s: %s", execution_state, err)
+
     def disconnect(self) -> None:
+        # Cancel nudge tasks first — they may still be running if the WebSocket
+        # closed before _nudge_kernel() completed.
+        for task in self._nudge_tasks:
+            task.cancel()
+        self._nudge_tasks.clear()
         # Cancel background recv tasks. They handle CancelledError gracefully.
         for task in self._tasks:
             task.cancel()


### PR DESCRIPTION
Builds on #248 (server-side execution).

This is a recreation and simplification of what exists in Jupyter Server today: https://github.com/jupyter-server/jupyter_server/blob/9ba7a60aea07ac84307f329bdf79e70bfb3bbe56/jupyter_server/services/kernels/connection/channels.py#L158

## The Problem 

When a user refreshes the page or reopens a notebook while a long-running cell is executing, the execution indicator in the top-right shows 'unknown' instead of 'busy'.

The root cause is that new WebSocket subscribers miss the `status:busy` iopub message the kernel already sent — ZMQ PUB/SUB has no replay for late joiners.

## The fix

The fix probes kernel state on connect by sending `kernel_info_request` on both the shell and control channels simultaneously, before starting the listen tasks to avoid racing them for messages. Control bypasses the execution queue and always replies; shell is blocked while executing. This is the same "nudge" approach used in `jupyter_server`.

The inferred state (idle/busy/unknown) is delivered to the browser as a synthetic `status` iopub message so the execution indicator shows the correct state immediately on reconnect.

There's also a fast path for ipykernel >= 7.2.0 (JEP [65](https://github.com/jupyter/enhancement-proposals/blob/master/65-jupyter-xpub/jupyter-xpub.md)): listening for `iopub_welcome` on the XPUB socket, which arrives ~5ms after connection and triggers early completion instead of waiting the full window.

The nudge logic lives in `nudge.py` as a standalone function so it can be reused from any context with an `AsyncKernelClient`, not just the WebSocket handler. The two timeouts (`kernel_info_timeout`, `kernel_info_reply_window`) are configurable traitlets.

## Follow up discussion

We could remove the synthetic status message by routing these messages into the ydoc, storing them in e.g. the global/document awareness somewhere, and letting the CRDT sync the state with all clients, instead of depending on a synthetic message. That should be done in a follow up PR though. 