### PR TITLE
Add E2E test for "New Console for Notebook" output rendering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+        run: python -m pip install -U "jupyterlab>=4.0.0,<4.6"
 
       - name: Lint the extension
         run: |
@@ -82,7 +82,7 @@ jobs:
           sudo rm -rf $(which node)
           sudo rm -rf $(which node)
 
-          pip install "jupyterlab>=4.0.0,<5" jupyter_server_documents*.whl
+          pip install "jupyterlab>=4.0.0,<4.6" jupyter_server_documents*.whl
 
 
           jupyter server extension list
@@ -115,7 +115,11 @@ jobs:
       - name: Install the extension
         run: |
           set -eux
-          python -m pip install "jupyterlab>=4.0.0,<5" jupyter_server_documents*.whl
+          # Pin jupyterlab <4.6: JupyterLab 4.6 bundles @jupyter/ydoc v4, but
+          # JSD's frontend (and its jupyter-collaboration/docprovider deps) are
+          # built against @jupyter/ydoc v3, so 4.6 breaks the extension (see
+          # #265 / #262). Drop this ceiling once JSD is upgraded to ydoc v4.
+          python -m pip install "jupyterlab>=4.0.0,<4.6" jupyter_server_documents*.whl
           # Optional deps exercised by the chat + router E2E tests
           # (tests/chat-sync.spec.ts, tests/chat-router.spec.ts). jupyterlab-chat
           # provides the .chat factory + YChat; jupyter-ai-router provides the

--- a/.github/workflows/update-integration-tests.yml
+++ b/.github/workflows/update-integration-tests.yml
@@ -72,7 +72,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+        run: python -m pip install -U "jupyterlab>=4.0.0,<4.6"
 
       - name: Install extension
         run: |

--- a/ui-tests/tests/console-for-notebook.spec.ts
+++ b/ui-tests/tests/console-for-notebook.spec.ts
@@ -1,0 +1,94 @@
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
+import {
+  acceptKernelDialog,
+  consoleOutputCount,
+  createConsoleForNotebook,
+  EMPTY_NOTEBOOK,
+  openDocument,
+  openedDocPath,
+  runInConsole,
+  uniqueToken
+} from './helpers';
+
+/**
+ * Don't load the JupyterLab webpage before running the tests, matching the
+ * convention in the other specs. Also disable galata's kernel/session/terminal
+ * API mocking: unlike the other specs (which run kernel-less), this test spins
+ * up a real `python3` kernel, and galata's session-tracking route handler
+ * crashes on the live session-creation response under JSD. Setting these to
+ * `null` lets the real API responses flow through untouched.
+ */
+test.use({
+  autoGoto: false,
+  kernels: null,
+  sessions: null,
+  terminals: null
+});
+
+/** Fixtures used by the test body below. */
+type Fixtures = { page: IJupyterLabPageFixture; tmpPath: string };
+
+/**
+ * Regression test for
+ * jupyter-ai-contrib/jupyter-server-documents#250 (and the upstream
+ * jupyterlab/jupyterlab#19010): a code console opened via "New Console for
+ * Notebook" renders **no output** when code is executed in it under JSD, while
+ * plain JupyterLab and jupyter-server-nbmodel render it correctly.
+ *
+ * Scenario:
+ *   1. Open a notebook with a live `python3` kernel, run `1 + 1` in the first
+ *      cell, and assert the cell output is `2` (the notebook path works).
+ *   2. Create a console for that notebook (the `notebook:create-console`
+ *      command behind the "New Console for Notebook" menu item), sharing the
+ *      notebook's kernel.
+ *   3. Run `1 + 1` in the console and assert the `2` output renders.
+ *
+ * The assertions describe the *correct* behavior, so this test fails on a build
+ * that still has the bug and passes once it's fixed.
+ */
+async function consoleForNotebookShowsOutput({
+  page,
+  tmpPath
+}: Fixtures): Promise<void> {
+  await page.goto();
+
+  const unique = uniqueToken();
+  const nbName = `console-for-nb-${unique}.ipynb`;
+  const targetPath = `${tmpPath}/${nbName}`;
+
+  // Create a minimal notebook, open it, and pick a real kernel (the console
+  // will inherit it) instead of dismissing the dialog.
+  await page.contents.uploadContent(EMPTY_NOTEBOOK, 'text', targetPath);
+  await openDocument(page, targetPath);
+  await acceptKernelDialog(page, 'python3');
+  await openedDocPath(page, nbName);
+
+  // 1. Run `1 + 1` in the notebook's first cell and confirm it outputs `2`.
+  await page.notebook.setCell(0, 'code', '1 + 1');
+  await page.notebook.runCell(0);
+  await page.notebook.waitForRun(0);
+  await expect
+    .poll(async () => await page.notebook.getCellTextOutput(0), {
+      timeout: 30000,
+      message: 'notebook cell never produced output'
+    })
+    .toEqual(expect.arrayContaining([expect.stringContaining('2')]));
+
+  // 2. Open a console for this notebook (shares the notebook's kernel).
+  await createConsoleForNotebook(page);
+
+  // 3. Run `1 + 1` in the console and confirm the `2` output renders. The bug
+  //    in #250 is that this output never appears under JSD.
+  await runInConsole(page, '1 + 1');
+  await expect
+    .poll(async () => await consoleOutputCount(page, '2'), {
+      timeout: 30000,
+      message: 'console execution produced no rendered output (issue #250)'
+    })
+    .toBeGreaterThan(0);
+}
+
+test(
+  'console created for a notebook renders execution output',
+  consoleForNotebookShowsOutput
+);

--- a/ui-tests/tests/helpers.ts
+++ b/ui-tests/tests/helpers.ts
@@ -303,6 +303,132 @@ export async function dismissKernelDialogIfPresent(
     .catch(() => undefined);
 }
 
+/**
+ * Accepts the "Select Kernel" dialog by choosing the given kernel (default
+ * `python3`), so the opened document gets a live kernel to execute against.
+ * Unlike {@link dismissKernelDialogIfPresent} this *requires* the dialog and a
+ * real kernel — used by tests that actually run code. No-op if no dialog
+ * appears (a kernel may already be attached).
+ */
+export async function acceptKernelDialog(
+  page: IJupyterLabPageFixture,
+  kernelName = 'python3'
+): Promise<void> {
+  const dialog = page.locator('.jp-Dialog');
+  try {
+    await dialog.waitFor({ state: 'visible', timeout: 10000 });
+  } catch {
+    return; // no dialog appeared
+  }
+  const combobox = dialog.getByRole('combobox');
+  if (await combobox.count()) {
+    // Option values mirror galata's createNew: `{"name":"<kernel>"}`.
+    await combobox
+      .selectOption(`{"name":"${kernelName}"}`)
+      .catch(() => undefined);
+  }
+  await dialog.locator('.jp-mod-accept').click();
+  await dialog
+    .waitFor({ state: 'hidden', timeout: 10000 })
+    .catch(() => undefined);
+}
+
+// ---------------------------------------------------------------------------
+// Code console fixtures
+//
+// Cover the "New Console for Notebook" flow (the `notebook:create-console`
+// command). A console created for a notebook shares the notebook's kernel; the
+// test executes a cell in it and asserts the output renders (regression guard
+// for jupyter-ai-contrib/jupyter-server-documents#250).
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a code console for the currently active notebook by executing the
+ * `notebook:create-console` command (the "New Console for Notebook" menu item),
+ * then waits until the console prompt cell is mounted and ready.
+ */
+export async function createConsoleForNotebook(
+  page: IJupyterLabPageFixture
+): Promise<void> {
+  await page.evaluate(async () => {
+    await (window as any).jupyterapp.commands.execute(
+      'notebook:create-console'
+    );
+  });
+  // The prompt (input) cell of a code console; present once the console panel
+  // is attached.
+  await page
+    .locator('.jp-CodeConsole .jp-CodeConsole-promptCell')
+    .first()
+    .waitFor({ state: 'visible', timeout: 30000 });
+
+  // Wait until the console's session has a *connected* kernel before we
+  // execute. The prompt cell mounts before the kernel is wired up, so executing
+  // too early silently drops the request (it never reaches a kernel → no
+  // output, a startup race that flaked under parallel load).
+  await page.waitForFunction(
+    () => {
+      const app = (window as any).jupyterapp;
+      for (const widget of app.shell.widgets('main')) {
+        const sc =
+          (widget as any).sessionContext ??
+          (widget as any).console?.sessionContext;
+        if (sc && typeof sc.kernelDisplayStatus === 'string') {
+          // A console panel: require a live kernel that has settled to idle.
+          return (
+            !sc.hasNoKernel &&
+            (sc.kernelDisplayStatus === 'idle' ||
+              sc.kernelDisplayStatus === 'busy')
+          );
+        }
+      }
+      return false;
+    },
+    undefined,
+    { timeout: 30000 }
+  );
+}
+
+/**
+ * Types `code` into the active console's prompt (real keystrokes → the
+ * editor → CRDT path), confirms the editor holds it, then executes via the
+ * `console:run-forced` command. Using the command instead of a `Shift+Enter`
+ * keypress avoids a focus race under parallel load, where the keypress could
+ * fire before the prompt held focus and silently drop the execution.
+ */
+export async function runInConsole(
+  page: IJupyterLabPageFixture,
+  code: string
+): Promise<void> {
+  const prompt = page
+    .locator('.jp-CodeConsole .jp-CodeConsole-promptCell .cm-content')
+    .first();
+  await prompt.click();
+  await prompt.pressSequentially(code);
+  // Ensure the keystrokes actually landed in the editor before executing.
+  await expect(prompt).toContainText(code, { timeout: 30000 });
+  await page.evaluate(async () => {
+    await (window as any).jupyterapp.commands.execute('console:run-forced');
+  });
+}
+
+/**
+ * Number of executed (non-prompt) console cells whose rendered output contains
+ * `text`. `0` means the output never rendered — the symptom of issue #250.
+ * Executed cells live in `.jp-CodeConsole-content`; the prompt cell is excluded
+ * so an echoed input never counts as output.
+ */
+export async function consoleOutputCount(
+  page: IJupyterLabPageFixture,
+  text: string
+): Promise<number> {
+  return page
+    .locator('.jp-CodeConsole-content .jp-OutputArea-output', {
+      hasText: text
+    })
+    .count();
+}
+
 // ---------------------------------------------------------------------------
 // jupyterlab-chat fixtures
 //


### PR DESCRIPTION

## Summary

Adds a Playwright/Galata UI test that captures the bug reported in #250 (and
its upstream counterpart jupyterlab/jupyterlab#19010): a code console opened via
**New Console for Notebook** rendered **no output** when code was executed in it
under `jupyter-server-documents`, while plain JupyterLab and
`jupyter-server-nbmodel` rendered it correctly.

The test asserts the **correct** behavior, so it acts as a regression guard: it
fails on a build that still has the bug and passes once the console output path
works. On the current branch the console path already works (the output
processor no longer intercepts console messages), so the test passes — and a
negative-control run confirmed it genuinely fails if the console produces no
output.

## Test scenario (`ui-tests/tests/console-for-notebook.spec.ts`)

1. Open a notebook with a live `python3` kernel, run `1 + 1` in the first cell,
   and assert the cell output is `2` (the notebook execution path works).
2. Create a console for that notebook via the `notebook:create-console` command
   (the "New Console for Notebook" menu item), sharing the notebook's kernel.
3. Run `1 + 1` in the console and assert the `2` output renders.

## Changes

- **`ui-tests/tests/console-for-notebook.spec.ts`** — the new spec. Disables
  galata's kernel/session/terminal API mocking (`kernels`/`sessions`/`terminals`
  set to `null`), since — unlike the other kernel-less specs — this one spins up
  a real kernel and galata's session-tracking route handler otherwise crashes on
  the live session-creation response under JSD.
- **`ui-tests/tests/helpers.ts`** — new shared helpers:
  - `acceptKernelDialog(page, kernel='python3')` — accept the "Select Kernel"
    dialog with a real kernel (counterpart to the existing
    `dismissKernelDialogIfPresent`).
  - `createConsoleForNotebook(page)` — run `notebook:create-console` and wait
    until the console's session has a **connected** kernel before returning
    (the prompt cell mounts before the kernel is wired up; executing too early
    silently drops the request — a startup race that flaked under parallel load).
  - `runInConsole(page, code)` — type into the console prompt with real
    keystrokes, confirm the editor holds the text, then execute via
    `console:run-forced` (avoids a focus race that a raw `Shift+Enter` keypress
    hit under parallel load).
  - `consoleOutputCount(page, text)` — count executed console cells whose
    rendered output contains `text` (excludes the prompt cell).

## Verification

- New test: **15×** parallel repeats green, plus 6× single-worker green.
- Full `ui-tests` suite: 6 passed, 4 skipped (optional chat/router deps).
- Negative control (asserting a token that can never appear) fails with the
  "issue #250" message, proving the assertion has real discriminating power.
- `prettier --check` and `eslint` clean.

Refs #250, jupyterlab/jupyterlab#19010