### PR TITLE
Retry failed room content loads; close the room on permanent failure instead of hanging clients

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -274,19 +274,29 @@ class YRoom(LoggingConfigurable):
             )
             self.file_api.load_content_into(self._jupyter_ydoc)
 
+            # Close this room if the content ultimately cannot be loaded, so
+            # that clients are disconnected instead of waiting forever on a
+            # document that will never sync, and so the next connection
+            # creates a fresh room, which retries the load.
+            assert self.file_api.content_load_task
+            self.file_api.content_load_task.add_done_callback(
+                self._on_content_load_done
+            )
+
             # Initialize YRoomEventsAPI
             EventsAPIClass = self.events_api_class
             self.events_api = EventsAPIClass(parent=self)
-        
+
         # Initialize message queue and start background task that routes new
         # messages in the message queue to the appropriate handler method.
         self._message_queue = asyncio.Queue()
-        asyncio.create_task(self._process_message_queue())
+        self._message_queue_task = asyncio.create_task(self._process_message_queue())
 
         # Log notification that room is ready
         self.log.info(f"Room '{self.room_id}' initialized.")
 
         # Emit events if defined
+        self._emit_load_event_task = None
         if self.events_api:
             # Emit 'initialize' event
             self.events_api.emit_room_event("initialize")
@@ -296,8 +306,43 @@ class YRoom(LoggingConfigurable):
             async def emit_load_event():
                 await self.file_api.until_content_loaded
                 self.events_api.emit_room_event("load")
-            asyncio.create_task(emit_load_event())
-    
+            self._emit_load_event_task = asyncio.create_task(emit_load_event())
+
+
+    def _on_content_load_done(self, task: asyncio.Task) -> None:
+        """Callback invoked when the initial content load task finishes.
+
+        If the load failed (after the retries performed by
+        `YRoomFileAPI._load_content()`), this stops the room and removes it
+        from the `YRoomManager`, so that:
+
+        - connected clients are disconnected (close code 1011) instead of
+          waiting forever on a document that will never sync, and
+        - the next connection to this room ID creates a fresh room, which
+          retries the load.
+        """
+        if task.cancelled() or task.exception() is None:
+            return
+
+        self.log.error(
+            f"Closing room '{self.room_id}' and disconnecting its clients "
+            "because the content could not be loaded. Reopening the document "
+            "will create a new room and retry the load.",
+            exc_info=task.exception(),
+        )
+
+        # Cancel the background tasks blocked on `until_content_loaded`,
+        # which never resolves after a failed load.
+        self._message_queue_task.cancel()
+        if self._emit_load_event_task:
+            self._emit_load_event_task.cancel()
+
+        # Stop with `immediately=True`: no content was loaded, so there are no
+        # pending updates worth applying, and saving the empty YDoc would
+        # overwrite the file.
+        self.stop(close_code=1011, immediately=True)
+        self.parent.discard_room(self.room_id)
+
 
     @property
     def fileid_manager(self) -> BaseFileIdManager:

--- a/jupyter_server_documents/rooms/yroom_file_api.py
+++ b/jupyter_server_documents/rooms/yroom_file_api.py
@@ -8,7 +8,7 @@ from jupyter_server.utils import ensure_async
 import logging
 from tornado.web import HTTPError
 from traitlets.config import LoggingConfigurable
-from traitlets import Float, validate
+from traitlets import Float, Int, validate
 
 if TYPE_CHECKING:
     from typing import Any, Coroutine, Literal
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 DEFAULT_MIN_POLL_INTERVAL = 0.5
 DEFAULT_POLL_INTERVAL_MULTIPLIER = 5.0
+DEFAULT_LOAD_RETRY_COUNT = 3
+DEFAULT_LOAD_RETRY_DELAY = 0.5
 class YRoomFileAPI(LoggingConfigurable):
     """Provides an API to interact with a single file for a YRoom.
 
@@ -63,6 +65,21 @@ class YRoomFileAPI(LoggingConfigurable):
         config=True,
     )
 
+    load_retry_count = Int(
+        default_value=DEFAULT_LOAD_RETRY_COUNT,
+        help="Number of times to retry the initial content load if it fails, "
+        "e.g. when the load races a concurrent write to a newly-created file. "
+        "Defaults to 3.",
+        config=True,
+    )
+
+    load_retry_delay = Float(
+        default_value=DEFAULT_LOAD_RETRY_DELAY,
+        help="Delay in seconds before the first content load retry. The delay "
+        "doubles on each subsequent retry. Defaults to 0.5 seconds.",
+        config=True,
+    )
+
     parent: YRoom
     """
     The parent `YRoom` instance that is using this instance.
@@ -88,6 +105,12 @@ class YRoomFileAPI(LoggingConfigurable):
     _save_scheduled: bool
     _content_loading: bool
     _content_load_event: asyncio.Event
+
+    _content_load_task: asyncio.Task | None
+    """
+    The task running `_load_content()`, started by `load_content_into()`.
+    `None` until loading first starts. See the `content_load_task` property.
+    """
 
     _last_modified: datetime | None
     """
@@ -156,6 +179,8 @@ class YRoomFileAPI(LoggingConfigurable):
         self._content_loading = False
         self._content_load_event = asyncio.Event()
         self._content_lock = asyncio.Lock()
+        self._content_load_task = None
+        self._watch_file_task = None
 
         # Initialize adaptive timing attributes
         self._adaptive_poll_interval = self.min_poll_interval
@@ -302,7 +327,19 @@ class YRoomFileAPI(LoggingConfigurable):
             return
 
         self._content_loading = True
-        asyncio.create_task(self._load_content(jupyter_ydoc))
+        self._content_load_task = asyncio.create_task(self._load_content(jupyter_ydoc))
+
+
+    @property
+    def content_load_task(self) -> asyncio.Task | None:
+        """The task running `_load_content()`, or `None` if loading has not
+        been started via `load_content_into()`.
+
+        Consumers may add a done-callback to this task to observe a load
+        failure. `until_content_loaded` cannot be used for this purpose, as it
+        never resolves when the load fails.
+        """
+        return self._content_load_task
 
 
     async def _get_content(self, path: str) -> tuple[Any, datetime]:
@@ -347,7 +384,47 @@ class YRoomFileAPI(LoggingConfigurable):
         return content, file_data['last_modified']
 
     async def _load_content(self, jupyter_ydoc: YBaseDoc) -> None:
-        """Internal method to load file content asynchronously.
+        """Internal method to load file content asynchronously, retrying on
+        failure.
+
+        The initial load can fail transiently, e.g. when it races a concurrent
+        write to the file by another process (a newly-created notebook may be
+        read while it is still being written, raising `NotJSONError`), so
+        failed attempts are retried up to `load_retry_count` times with
+        exponential backoff starting at `load_retry_delay` seconds.
+
+        If every attempt fails, `_content_loading` is reset so that a future
+        `load_content_into()` call can try again, and the final exception is
+        re-raised so it is observable on `content_load_task`.
+
+        Args:
+            jupyter_ydoc: The YBaseDoc instance to load content into.
+        """
+        attempt = 0
+        delay = self.load_retry_delay
+        while True:
+            try:
+                return await self._load_content_once(jupyter_ydoc)
+            except Exception:
+                if self._stopped or attempt >= self.load_retry_count:
+                    self._content_loading = False
+                    self.log.exception(
+                        f"Failed to load content for room '{self.room_id}' "
+                        f"after {attempt + 1} attempt(s)."
+                    )
+                    raise
+                attempt += 1
+                self.log.warning(
+                    f"Failed to load content for room '{self.room_id}' "
+                    f"(attempt {attempt} of {self.load_retry_count + 1}). "
+                    f"Retrying in {delay}s.",
+                    exc_info=True,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+
+    async def _load_content_once(self, jupyter_ydoc: YBaseDoc) -> None:
+        """Performs a single attempt at loading the file content.
 
         Resolves the file path, loads content from ContentsManager, processes
         notebook outputs if applicable, and initializes the YDoc. Finally,

--- a/jupyter_server_documents/rooms/yroom_manager.py
+++ b/jupyter_server_documents/rooms/yroom_manager.py
@@ -221,6 +221,21 @@ class YRoomManager(LoggingConfigurable):
             return False
     
     
+    def discard_room(self, room_id: str) -> None:
+        """
+        Removes a YRoom from this manager WITHOUT saving its content, so the
+        next connection to this room ID creates a fresh room.
+
+        This is used by `YRoom` when a room failed to initialize (i.e. its
+        content could not be loaded), where saving the (empty) YDoc via
+        `delete_room()` would overwrite the file on disk. Callers are
+        responsible for stopping the room first.
+        """
+        self._rooms_by_id.pop(room_id, None)
+        self._inactive_rooms.discard(room_id)
+        self._freeing_rooms.discard(room_id)
+
+
     def list_document_rooms(self) -> list[YRoom]:
         """
         Lists all document rooms, excluding "JupyterLab:globalAwareness".

--- a/jupyter_server_documents/tests/test_yroom_file_api.py
+++ b/jupyter_server_documents/tests/test_yroom_file_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 import pytest_asyncio
 import shutil
@@ -5,6 +6,7 @@ from pathlib import Path
 import os
 from typing import Awaitable
 import pycrdt
+from tornado.web import HTTPError
 from traitlets.config import LoggingConfigurable
 
 from ..rooms import YRoomFileAPI
@@ -118,7 +120,80 @@ async def test_load_plaintext_file(
     with open(mock_plaintext_file) as f:
         content = f.read()
     assert jupyter_ydoc.source == content
-    
+
     # stop file file api to avoid coroutine warnings
+    file_api.stop()
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_load_retries_transient_failure(
+    plaintext_file_api: YRoomFileAPI,
+    empty_yunicode: YUnicode,
+    mock_plaintext_file: str,
+    jp_contents_manager: AsyncFileContentsManager,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Asserts that the content load retries and succeeds when the first read
+    fails transiently, e.g. when the load races a concurrent write to a
+    newly-created file (#267).
+    """
+    file_api = plaintext_file_api
+    file_api.load_retry_delay = 0.01
+
+    original_get = jp_contents_manager.get
+    call_count = {"total": 0}
+
+    async def flaky_get(*args, **kwargs):
+        call_count["total"] += 1
+        if call_count["total"] == 1:
+            raise HTTPError(400, "simulated transient read failure")
+        return await original_get(*args, **kwargs)
+
+    monkeypatch.setattr(jp_contents_manager, "get", flaky_get)
+
+    file_api.load_content_into(empty_yunicode)
+    await asyncio.wait_for(file_api.until_content_loaded, timeout=5)
+
+    with open(mock_plaintext_file) as f:
+        assert empty_yunicode.source == f.read()
+    assert call_count["total"] == 2
+
+    file_api.stop()
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_load_failure_is_observable_and_recoverable(
+    plaintext_file_api: YRoomFileAPI,
+    empty_yunicode: YUnicode,
+    jp_contents_manager: AsyncFileContentsManager,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Asserts that when every load attempt fails, the exception is observable
+    on `content_load_task` and the file API allows a later
+    `load_content_into()` call to retry, instead of reporting
+    "already loading" forever (#267).
+    """
+    file_api = plaintext_file_api
+    file_api.load_retry_count = 1
+    file_api.load_retry_delay = 0.01
+
+    async def failing_get(*args, **kwargs):
+        raise HTTPError(400, "simulated permanent read failure")
+
+    monkeypatch.setattr(jp_contents_manager, "get", failing_get)
+
+    file_api.load_content_into(empty_yunicode)
+    assert file_api.content_load_task is not None
+    with pytest.raises(HTTPError):
+        await asyncio.wait_for(file_api.content_load_task, timeout=5)
+
+    assert not file_api.content_loaded
+    # A new `load_content_into()` call must be able to start a fresh attempt.
+    monkeypatch.undo()
+    file_api.load_content_into(empty_yunicode)
+    await asyncio.wait_for(file_api.until_content_loaded, timeout=5)
+
     file_api.stop()
 

--- a/jupyter_server_documents/tests/test_yroom_manager.py
+++ b/jupyter_server_documents/tests/test_yroom_manager.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
+import asyncio
 import pytest
+from tornado.web import HTTPError
+from traitlets.config import Config
 from jupyter_server_documents.rooms.yroom_manager import YRoomManager
 from jupyter_server_documents.rooms.yroom import YRoom
 from typing import TYPE_CHECKING
@@ -57,3 +60,50 @@ class TestYRoomManager():
         manager = make_yroom_manager()
         result = await manager.delete_room("text:file:nonexistent")
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_failed_room_is_discarded_and_recreated(
+        self,
+        make_yroom_manager: MakeYRoomManager,
+        make_room_file: MakeRoomFile,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """
+        Asserts that a room whose content load fails (after retries) is
+        stopped and discarded from the manager, and that the next
+        `get_room()` call creates a fresh room that loads successfully
+        instead of returning the dead room (#267).
+        """
+        config = Config()
+        config.YRoomFileAPI.load_retry_count = 1
+        config.YRoomFileAPI.load_retry_delay = 0.01
+        manager = make_yroom_manager(config=config)
+        room_id = make_room_file()
+
+        # Fail the first 2 reads (initial attempt + 1 retry), then recover.
+        original_get = manager.contents_manager.get
+        failures_left = {"count": 2}
+
+        async def flaky_get(*args, **kwargs):
+            if failures_left["count"] > 0:
+                failures_left["count"] -= 1
+                raise HTTPError(400, "simulated transient read failure")
+            return await original_get(*args, **kwargs)
+
+        monkeypatch.setattr(manager.contents_manager, "get", flaky_get)
+
+        room = manager.get_room(room_id)
+        assert room is not None
+        with pytest.raises(HTTPError):
+            await asyncio.wait_for(room.file_api.content_load_task, timeout=5)
+
+        # Let the done-callback stop the room and discard it from the manager.
+        await asyncio.sleep(0.1)
+        assert manager.has_room(room_id) is False
+
+        # The next connection creates a fresh room, which loads successfully.
+        new_room = manager.get_room(room_id)
+        assert new_room is not None
+        assert new_room is not room
+        await asyncio.wait_for(new_room.file_api.until_content_loaded, timeout=5)
+        new_room.stop(immediately=True)


### PR DESCRIPTION
Fixes #267. Also fixes #268 (the `_watch_file_task` `AttributeError`, which sits directly on this failure path).

## Problem

When a `YRoom`'s initial content load raises (in the wild: an `HTTPError` wrapping `NotJSONError`, from the load racing a concurrent write to a just-created notebook — e.g. an AI agent creating a notebook via `jupyter-mcp-server` while the user's JupyterLab opens it immediately), the room is permanently unusable:

- the exception only surfaces as `Task exception was never retrieved`;
- `until_content_loaded` never resolves, so `_process_message_queue()` never processes a message;
- every client that connects completes the websocket handshake but never receives a reply to sync step 1 — the notebook sits on an infinite loading screen with nothing actionable, until the server restarts.

## Fix

Three parts, matching the remedies suggested in #267:

1. **Retry the load.** `YRoomFileAPI._load_content()` now retries with exponential backoff (new `load_retry_count` / `load_retry_delay` configurable traits, defaults 3 retries starting at 0.5s). The observed failure is transient — the file is valid JSON milliseconds later — so this absorbs the common case.
2. **Make failure observable and recoverable.** The load task is kept on a new `content_load_task` property so consumers can attach done-callbacks (`until_content_loaded` can't be used for this — it never resolves on failure). On terminal failure `_content_loading` is reset, so a later `load_content_into()` can try again instead of being ignored as "already loading".
3. **Fail the room fast.** `YRoom` watches the load task; on terminal failure it cancels the tasks blocked on `until_content_loaded`, stops the room — disconnecting clients with close code 1011 so they see an error instead of waiting forever — and removes it from the manager via the new `YRoomManager.discard_room()`. The next connection creates a fresh room and retries the load. `discard_room()` deliberately does not save: the YDoc is empty at this point, and `delete_room()`'s save would overwrite the user's file.

Additionally, `_watch_file_task` (and `_content_load_task`) are now initialized to `None` in `__init__`, fixing the `AttributeError` in `stop()` when the room is torn down before a load ever completed (#268) — which is exactly what the fail-fast path does.

## Tests

- `test_load_retries_transient_failure` — first read raises, retry succeeds, content correct.
- `test_load_failure_is_observable_and_recoverable` — permanent failure raises on `content_load_task`; a later `load_content_into()` succeeds.
- `test_failed_room_is_discarded_and_recreated` — end-to-end through `YRoomManager`: load fails after retries, room is stopped and discarded, next `get_room()` returns a fresh room that loads successfully.

Full suite passes: 145 passed.

## Notes for reviewers

- This PR has been generated with Claude Fable.
- Downstream user-visible symptom this resolves: agent creates a notebook, the user opens it immediately, the tab hangs forever (also reported as datalayer/jupyter-mcp-server#246).
- Backoff doubles each retry (0.5 → 1 → 2s by default, ~3.5s total before giving up); happy-path behavior and timing are unchanged.
