### PR TITLE
Prevent a disconnected client from poisoning a room's message queue

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -554,12 +554,21 @@ class YRoom(LoggingConfigurable):
 
             # Otherwise, process & handle the new message
             client_id, message = queue_item
-            await self.handle_message(client_id, message)
-            
-            # Finally, inform the asyncio Queue that the task was complete
-            # This is required for `self._message_queue.join()` to unblock once
-            # queue is empty in `self.stop()`.
-            self._message_queue.task_done()
+            try:
+                await self.handle_message(client_id, message)
+            except Exception:
+                # A failure while handling one message (e.g. a stale frame from
+                # a disconnected client) must not halt the queue task, as that
+                # would silently stop message processing for the entire room.
+                self.log.exception(
+                    f"Error handling message from client '{client_id}' in "
+                    f"YRoom '{self.room_id}'. Skipping this message."
+                )
+            finally:
+                # Inform the asyncio Queue that the task was complete, even on
+                # failure. This is required for `self._message_queue.join()` to
+                # unblock once queue is empty in `self.stop()`.
+                self._message_queue.task_done()
 
         self.log.debug(
             "Stopped `self._process_message_queue()` background task "

--- a/jupyter_server_documents/tests/test_clients.py
+++ b/jupyter_server_documents/tests/test_clients.py
@@ -1,0 +1,59 @@
+"""Tests for YjsClientGroup, the per-room client registry.
+
+Regression coverage for #271: a lookup of an unknown client must raise a
+proper exception (not UnboundLocalError), so the caller's exception boundary
+can skip the offending message instead of poisoning the room's queue.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from jupyter_server_documents.websockets.clients import YjsClientGroup
+
+
+class FakeWebSocket:
+    """Minimal stand-in for a Tornado WebSocketHandler."""
+
+    def __init__(self, connected: bool = True):
+        # `get()` checks both `websocket` and `websocket.ws_connection`.
+        self.ws_connection = object() if connected else None
+        self.closed = False
+
+    def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def group() -> YjsClientGroup:
+    return YjsClientGroup(room_id="test-room", log=logging.getLogger("test"))
+
+
+def test_get_unknown_client_raises_exception(group: YjsClientGroup):
+    """An unknown client_id must raise a proper Exception, not UnboundLocalError."""
+    with pytest.raises(Exception) as exc_info:
+        group.get("does-not-exist")
+    assert "does-not-exist" in str(exc_info.value)
+    assert not isinstance(exc_info.value, UnboundLocalError)
+
+
+def test_get_desynced_client(group: YjsClientGroup):
+    """A desynced (newly added) client is returned by get()."""
+    client_id = group.add(FakeWebSocket())
+    assert group.get(client_id).id == client_id
+
+
+def test_get_synced_client(group: YjsClientGroup):
+    """A synced client is returned by get()."""
+    client_id = group.add(FakeWebSocket())
+    group.mark_synced(client_id)
+    assert group.get(client_id).id == client_id
+
+
+def test_get_disconnected_client_raises(group: YjsClientGroup):
+    """A client whose websocket has no live connection is treated as missing."""
+    client_id = group.add(FakeWebSocket(connected=False))
+    with pytest.raises(Exception):
+        group.get(client_id)

--- a/jupyter_server_documents/tests/test_yroom_sync.py
+++ b/jupyter_server_documents/tests/test_yroom_sync.py
@@ -396,3 +396,40 @@ class TestSyncUpdateChannel:
 
         # Handshake complete: the channel must be resumed.
         assert yroom.update_channel._paused is False
+
+
+class TestQueuePoisoning:
+    """Regression tests for #271: a message that raises while being handled
+    must not halt the room's message queue for everyone else."""
+
+    @pytest.mark.asyncio
+    async def test_stale_client_update_does_not_poison_queue(
+        self, make_yroom: MakeYRoom
+    ):
+        """A SyncUpdate from an unknown/disconnected client raises in the
+        handler, but the queue task must keep processing later messages so a
+        fresh client can still complete its handshake."""
+        yroom = await make_yroom()
+
+        # A stale SyncUpdate frame referencing a client_id the room never knew
+        # about (e.g. left behind by a client that disconnected abruptly). This
+        # reaches handle_sync_update -> _should_ignore_update -> clients.get(),
+        # which raises because the client is absent.
+        stale_update = bytes(
+            [YMessageType.SYNC, YSyncMessageSubtype.SYNC_UPDATE]
+        ) + b"\x00"
+        yroom.add_message("ghost-client", stale_update)
+        await asyncio.sleep(0.1)
+
+        # The queue must have survived: a fresh client can still sync.
+        ws = FakeWebSocket()
+        client_id = yroom.clients.add(ws)
+        yroom.add_message(client_id, ws.build_ss1())
+        await asyncio.sleep(0.1)
+
+        ss2_reply = ws.process_server_messages()
+        assert ss2_reply is not None
+        yroom.add_message(client_id, ss2_reply)
+        await asyncio.sleep(0.1)
+
+        assert yroom.clients.get(client_id).synced

--- a/jupyter_server_documents/websockets/clients.py
+++ b/jupyter_server_documents/websockets/clients.py
@@ -134,11 +134,8 @@ class YjsClientGroup:
         """
         Gets a client from its ID.
         """
-        if client_id in self.desynced: 
-            client = self.desynced[client_id]
-        if client_id in self.synced:
-            client = self.synced[client_id]
-        if client.websocket and client.websocket.ws_connection:
+        client = self.synced.get(client_id) or self.desynced.get(client_id)
+        if client and client.websocket and client.websocket.ws_connection:
             return client
         error_message = f"The client_id '{client_id}' is not found in client group in room '{self.room_id}'"
         self.log.error(error_message)


### PR DESCRIPTION
A stale SyncUpdate frame from a client that has already disconnected could permanently halt a room's message-queue task, silently stopping message processing for every other client in the room (#271).

Two independent defects combined to cause this:

- YjsClientGroup.get() raised UnboundLocalError when a client_id was in neither the synced nor desynced group, because `client` was never bound. Consolidate the lookup so a missing client raises the intended exception.

- _process_message_queue() had no exception boundary around handle_message(), so any raised exception killed the queue task and left subsequent messages stuck. Wrap the call in try/except/finally: log and skip the failing message, always call task_done(), and keep the room processing.

Add regression tests for both the get() lookup and queue survival.