### PR TITLE
Send current awareness state to clients on connect

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -759,6 +759,28 @@ class YRoom(LoggingConfigurable):
             )
             raise
 
+        # Send the room's *current* awareness state to this client only.
+        #
+        # Awareness is otherwise broadcast solely as change deltas (see
+        # `_on_awareness_update`), so a newly-synced client would not learn any
+        # slot published before it connected until a later delta happened to
+        # re-touch that slot -- delaying e.g. personas by seconds on refresh
+        # (jupyter-ai-contrib/jupyter-server-documents#279). Encoding the full
+        # current state here and writing it to this socket alone closes that gap
+        # without re-broadcasting to peers that already have the state.
+        try:
+            client_ids = list(self._awareness.states.keys())
+            if client_ids:
+                awareness_update = self._awareness.encode_awareness_update(client_ids)
+                awareness_message = pycrdt.create_awareness_message(awareness_update)
+                new_client.websocket.write_message(awareness_message, binary=True)
+        except Exception as e:
+            self.log.exception(
+                "An exception occurred when writing the current awareness state "
+                f"to newly-synced client '{new_client.id}':"
+            )
+            raise
+
     def handle_sync_step2(self, client_id: str, message: bytes) -> None:
         """
         Applies a SyncStep2 message from a client to the YDoc.

--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -748,17 +748,6 @@ class YRoom(LoggingConfigurable):
             )
             raise
 
-        # Send SyncStep1 message to client
-        try:
-            sync_step1_message = pycrdt.create_sync_message(self._ydoc)
-            new_client.websocket.write_message(sync_step1_message, binary=True)
-        except Exception as e:
-            self.log.exception(
-                "An exception occurred when writing a SyncStep1 message "
-                f"to newly-synced client '{new_client.id}':"
-            )
-            raise
-
         # Send the room's *current* awareness state to this client only.
         #
         # Awareness is otherwise broadcast solely as change deltas (see
@@ -768,6 +757,12 @@ class YRoom(LoggingConfigurable):
         # (jupyter-ai-contrib/jupyter-server-documents#279). Encoding the full
         # current state here and writing it to this socket alone closes that gap
         # without re-broadcasting to peers that already have the state.
+        #
+        # This is sent right after the SS2 reply (which carries the current YDoc
+        # state) and before the SS1 request: both "here's the server's current
+        # state" messages travel together, and awareness reaches the client
+        # before we ask it for its own updates. It is still after `mark_synced`,
+        # so a desynced client mid-handshake is never sent a snapshot.
         try:
             client_ids = list(self._awareness.states.keys())
             if client_ids:
@@ -777,6 +772,17 @@ class YRoom(LoggingConfigurable):
         except Exception as e:
             self.log.exception(
                 "An exception occurred when writing the current awareness state "
+                f"to newly-synced client '{new_client.id}':"
+            )
+            raise
+
+        # Send SyncStep1 message to client
+        try:
+            sync_step1_message = pycrdt.create_sync_message(self._ydoc)
+            new_client.websocket.write_message(sync_step1_message, binary=True)
+        except Exception as e:
+            self.log.exception(
+                "An exception occurred when writing a SyncStep1 message "
                 f"to newly-synced client '{new_client.id}':"
             )
             raise

--- a/jupyter_server_documents/tests/test_yroom_sync.py
+++ b/jupyter_server_documents/tests/test_yroom_sync.py
@@ -77,6 +77,17 @@ class FakeWebSocket:
                     ss2_reply = reply
         return ss2_reply
 
+    def awareness_states(self) -> dict[int, dict]:
+        """Decode every AwarenessUpdate the server sent to this client and
+        return the resulting merged awareness states, keyed by client ID."""
+        awareness = pycrdt.Awareness(Doc())
+        for msg in self.messages:
+            if len(msg) < 2 or msg[0] != YMessageType.AWARENESS:
+                continue
+            payload = pycrdt.read_message(msg[1:])
+            awareness.apply_awareness_update(payload, origin=self)
+        return awareness.states
+
     @property
     def source(self) -> str:
         return str(self.doc["source"])
@@ -396,3 +407,103 @@ class TestSyncUpdateChannel:
 
         # Handshake complete: the channel must be resumed.
         assert yroom.update_channel._paused is False
+
+
+def _seed_room_awareness(yroom: YRoom, **state) -> int:
+    """Publish an awareness slot into the room from a simulated *other*
+    client (e.g. a persona) and return that client's awareness ID.
+
+    This mirrors how a peer publishes awareness before a new client connects:
+    the peer encodes its local state and the room applies it via
+    `handle_awareness_update`.
+    """
+    peer = pycrdt.Awareness(Doc())
+    for field, value in state.items():
+        peer.set_local_state_field(field, value)
+    update = peer.encode_awareness_update([peer.client_id])
+    yroom.handle_awareness_update("peer", pycrdt.create_awareness_message(update))
+    return peer.client_id
+
+
+class TestAwarenessOnConnect:
+    """A newly-synced client must receive the room's *current* awareness state
+    as part of the handshake, not only via later change deltas.
+
+    Regression test for jupyter-ai-contrib/jupyter-server-documents#279: awareness
+    published before a client connects (e.g. a persona) would only reach that
+    client when a subsequent delta happened to re-touch the slot, causing
+    seconds-long delays before personas appeared on refresh.
+    """
+
+    @pytest.mark.asyncio
+    async def test_client_receives_existing_awareness_on_connect(
+        self, make_yroom: MakeYRoom
+    ):
+        """A slot published *before* the client connects must be delivered by
+        the handshake alone -- with no further awareness mutation."""
+        yroom = await make_yroom()
+        peer_id = _seed_room_awareness(yroom, name="Jupyternaut", type="persona")
+
+        ws = FakeWebSocket()
+        await _complete_handshake(yroom, ws)
+
+        # The handshake alone (no later delta) must have delivered the slot.
+        states = ws.awareness_states()
+        assert peer_id in states
+        assert states[peer_id] == {"name": "Jupyternaut", "type": "persona"}
+
+    @pytest.mark.asyncio
+    async def test_awareness_snapshot_only_to_new_client(
+        self, make_yroom: MakeYRoom
+    ):
+        """The snapshot must go *only* to the newly-synced client, not be
+        re-broadcast to peers already in the room."""
+        yroom = await make_yroom()
+
+        # An existing, already-synced client.
+        ws_a = FakeWebSocket()
+        await _complete_handshake(yroom, ws_a)
+
+        _seed_room_awareness(yroom, name="Jupyternaut", type="persona")
+
+        # Snapshot A's message count *after* the seed delta broadcast, right
+        # before B connects. Any growth beyond this during B's handshake would
+        # be a spurious room-wide re-broadcast of the connect snapshot.
+        a_msgs_before_b = len(ws_a.messages)
+
+        # A second client connects and completes the handshake.
+        ws_b = FakeWebSocket()
+        await _complete_handshake(yroom, ws_b)
+
+        # The new client received the snapshot...
+        assert any(
+            len(m) >= 2 and m[0] == YMessageType.AWARENESS for m in ws_b.messages
+        )
+        # ...but the existing client received nothing extra from B's handshake.
+        assert len(ws_a.messages) == a_msgs_before_b
+
+    @pytest.mark.asyncio
+    async def test_awareness_snapshot_sent_after_sync_step2(
+        self, make_yroom: MakeYRoom
+    ):
+        """The snapshot must be sent *after* mark_synced, i.e. after the SS2
+        reply that marks the client synced -- never before. Verify by message
+        ordering: the AwarenessUpdate follows the first SYNC message."""
+        yroom = await make_yroom()
+        _seed_room_awareness(yroom, name="Jupyternaut", type="persona")
+
+        ws = FakeWebSocket()
+        await _complete_handshake(yroom, ws)
+
+        first_sync_idx = next(
+            i for i, m in enumerate(ws.messages)
+            if len(m) >= 2 and m[0] == YMessageType.SYNC
+        )
+        awareness_idxs = [
+            i for i, m in enumerate(ws.messages)
+            if len(m) >= 2 and m[0] == YMessageType.AWARENESS
+        ]
+        assert awareness_idxs, "client never received an AwarenessUpdate"
+        # Every awareness snapshot arrives after the SS2 sync reply that ran
+        # mark_synced -- so a desynced client is never sent one.
+        assert min(awareness_idxs) > first_sync_idx

--- a/ui-tests/jsd_test_ext.py
+++ b/ui-tests/jsd_test_ext.py
@@ -167,6 +167,45 @@ class _RecreateRoomHandler(APIHandler):
         self.finish(json.dumps({"freed": freed}))
 
 
+class _SeedAwarenessHandler(APIHandler):
+    """Publish an awareness slot into a file's room from a simulated *peer*.
+
+    This mimics another participant (e.g. an AI persona) announcing its
+    presence via awareness. The state is applied through the room's normal
+    ``handle_awareness_update`` path, so it lands in the room's awareness map
+    exactly as a real peer's would -- letting the awareness-on-connect E2E seed
+    a slot while the browser is offline, then assert the browser receives it on
+    reconnect (jupyter-ai-contrib/jupyter-server-documents#279).
+
+    Returns the peer's awareness client id (as a string) so the test can target
+    that specific slot.
+    """
+
+    @tornado.web.authenticated
+    async def post(self):
+        import pycrdt
+
+        path = self.get_argument("path")
+        token = self.get_argument("token")
+        rooms = _rooms_for_path(self.settings, path)
+        if not rooms:
+            raise tornado.web.HTTPError(404, f"No open room for path '{path}'.")
+        room = rooms[0]
+
+        # Build an awareness update from a throwaway peer and apply it to the
+        # room. The peer never renews its clock, so no later delta re-touches
+        # this slot -- which is precisely why a client that connected afterwards
+        # would never learn it without the snapshot-on-connect fix.
+        peer = pycrdt.Awareness(pycrdt.Doc())
+        peer.set_local_state_field("persona", {"name": token, "id": token})
+        update = peer.encode_awareness_update([peer.client_id])
+        room.handle_awareness_update("seed-peer", pycrdt.create_awareness_message(update))
+
+        self.finish(
+            json.dumps({"room_id": room.room_id, "peer_client_id": str(peer.client_id)})
+        )
+
+
 def _jupyter_server_extension_points():
     return [{"module": "jsd_test_ext"}]
 
@@ -185,6 +224,10 @@ def _load_jupyter_server_extension(server_app):
             (
                 url_path_join(base_url, "jsd-test", "router-fires"),
                 _RouterFiresHandler,
+            ),
+            (
+                url_path_join(base_url, "jsd-test", "seed-awareness"),
+                _SeedAwarenessHandler,
             ),
         ],
     )

--- a/ui-tests/tests/awareness-on-connect.spec.ts
+++ b/ui-tests/tests/awareness-on-connect.spec.ts
@@ -1,0 +1,121 @@
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
+import {
+  closeDocument,
+  getClientAwareness,
+  getRoomInfo,
+  openDocument,
+  openedDocPath,
+  seedAwareness,
+  uniqueToken,
+  waitForRoom,
+  waitForServerContent,
+  typeInFileEditor
+} from './helpers';
+
+/**
+ * Awareness-on-connect (jupyter-ai-contrib/jupyter-server-documents#279).
+ *
+ * A client that connects (or refreshes) must receive the room's *current*
+ * awareness state as part of the sync handshake — not only when a later change
+ * delta happens to re-touch a slot. Before the fix, awareness was broadcast
+ * solely as deltas, so a slot published while the client wasn't connected (e.g.
+ * a persona that announced itself before the client opened the document) could
+ * take many seconds to appear, or never appear until something mutated it
+ * again. This surfaced downstream as personas taking ~10s to load on refresh
+ * (jupyter-ai-contrib/jupyter-ai-persona-manager#76).
+ *
+ * Reproduction — the fresh-connect path, matching the production scenario:
+ *
+ *   1. Open the document (client connects, room created).
+ *   2. Close it (client disconnects; the room survives — GC is 60s).
+ *   3. Seed a persona awareness slot into the still-alive room while no client
+ *      is connected. The seeded peer never renews its clock, so no later delta
+ *      re-touches the slot.
+ *   4. Reopen the document — a genuinely fresh sync handshake against the same
+ *      room, exactly like a browser refresh.
+ *
+ * On `main` step 4's handshake never carries awareness, so the persona slot
+ * doesn't arrive within the window (its only hope is the seeded peer aging out
+ * / renewing, which it doesn't) and the poll times out. With the fix the slot
+ * rides the handshake and appears well under the 5s bar enforced here.
+ */
+
+test.use({ autoGoto: false });
+
+type Fixtures = { page: IJupyterLabPageFixture; tmpPath: string };
+
+/** The connect-to-awareness bar: personas must load fast, not in ~10s. */
+const AWARENESS_DEADLINE_MS = 5000;
+
+test('awareness present in a room is delivered on fresh connect', async ({
+  page,
+  tmpPath
+}: Fixtures) => {
+  await page.goto();
+
+  const unique = uniqueToken();
+  const fileName = `awareness-${unique}.txt`;
+  const targetPath = `${tmpPath}/${fileName}`;
+  const edit = `ALPHA-${unique}`;
+  const personaToken = `PERSONA-${unique}`;
+
+  await page.contents.uploadContent('', 'text', targetPath);
+  await openDocument(page, targetPath);
+  const path = await openedDocPath(page, fileName);
+  await waitForRoom(page, path);
+
+  // Establish + sync an edit so the room is live and on disk, then capture the
+  // room's clientID: reopening must hit this *same* room (not a recreated one).
+  await typeInFileEditor(page, edit);
+  await waitForServerContent(page, path, edit);
+  const before = await getRoomInfo(page, path);
+  expect(before).not.toBeNull();
+
+  // Disconnect this client by closing the document. The room stays alive.
+  await closeDocument(page, path);
+
+  // Publish a persona's awareness into the room while no client is connected,
+  // so there is no live delta for any client to observe — the slot exists only
+  // in the room's awareness map.
+  const peerClientId = await seedAwareness(page, path, personaToken);
+  const room = await getRoomInfo(page, path);
+  expect(room, 'room should survive the disconnect').not.toBeNull();
+  expect(room!.client_id).toBe(before!.client_id);
+
+  // Reopen: a fresh sync handshake against the same room (like a refresh).
+  const reopenStart = Date.now();
+  await openDocument(page, targetPath);
+  const reopenedPath = await openedDocPath(page, fileName);
+
+  // Time how long the persona takes to appear in the reconnected client's
+  // awareness. This is the connect path #279 fixes.
+  await expect
+    .poll(
+      async () => {
+        const states = await getClientAwareness(page, reopenedPath);
+        return states != null && peerClientId in states;
+      },
+      {
+        timeout: AWARENESS_DEADLINE_MS,
+        message:
+          'client never received the persona awareness slot within the ' +
+          `${AWARENESS_DEADLINE_MS}ms deadline (issue #279)`
+      }
+    )
+    .toBe(true);
+
+  const elapsed = Date.now() - reopenStart;
+
+  // Same room throughout — proves we exercised the ordinary connect handshake,
+  // not a divergent room-recreation path.
+  const after = await getRoomInfo(page, reopenedPath);
+  expect(after).not.toBeNull();
+  expect(after!.client_id).toBe(before!.client_id);
+
+  // The slot carries the seeded persona payload, and it loaded fast.
+  const finalStates = await getClientAwareness(page, reopenedPath);
+  expect(finalStates?.[peerClientId]).toMatchObject({
+    persona: { name: personaToken, id: personaToken }
+  });
+  expect(elapsed).toBeLessThan(AWARENESS_DEADLINE_MS);
+});

--- a/ui-tests/tests/helpers.ts
+++ b/ui-tests/tests/helpers.ts
@@ -220,6 +220,46 @@ export async function openDocument(
 }
 
 /**
+ * Closes (disposes) the open document widget at the exact `path`, disconnecting
+ * its provider from the room. The server-side room stays alive well past this
+ * (inactivity GC is 60s), so a subsequent {@link openDocument} of the same path
+ * performs a *fresh* sync handshake against the same room — the connect path
+ * exercised by the awareness-on-connect test. Resolves once no widget for the
+ * path remains open.
+ */
+export async function closeDocument(
+  page: IJupyterLabPageFixture,
+  path: string
+): Promise<void> {
+  await page.evaluate((p: string) => {
+    const app = (window as any).jupyterapp;
+    for (const widget of app.shell.widgets('main')) {
+      if ((widget as any).context?.path === p) {
+        widget.close();
+      }
+    }
+  }, path);
+  // Closing may raise a "Save your changes?" dialog. With RTC the content is
+  // already on the server, so discard is safe — accept whatever dialog appears.
+  const dialog = page.locator('.jp-Dialog');
+  try {
+    await dialog.waitFor({ state: 'visible', timeout: 3000 });
+    await dialog.locator('.jp-mod-accept').first().click();
+  } catch {
+    // No dialog appeared — nothing to dismiss.
+  }
+  await expect
+    .poll(
+      async () => (await getDocPath(page, path.split('/').pop()!)) === null,
+      {
+        timeout: 30000,
+        message: 'document widget never closed'
+      }
+    )
+    .toBe(true);
+}
+
+/**
  * Resolves the open document's real server path, polling until the widget is
  * open. Galata stores files under a per-test temp dir, so the path differs from
  * the bare file name.
@@ -502,6 +542,66 @@ export async function renderedMessageCount(
       hasText: sentinel
     })
     .count();
+}
+
+/**
+ * Publishes an awareness slot into the file's room from a simulated *peer* (as
+ * an AI persona would), via the test-only `/jsd-test/seed-awareness` endpoint.
+ * The slot carries `token` and is never renewed, so no later change delta
+ * re-touches it — mirroring a persona that announced itself before a client
+ * connected. Returns the peer's awareness client id (as a string).
+ *
+ * Unlike the other `/jsd-test/*` helpers this issues the request from Node via
+ * Playwright's `page.request` (APIRequestContext), not from inside the browser.
+ * That matters because the awareness-on-connect test seeds *while the browser
+ * is offline* (`context().setOffline(true)`), which would block an in-page
+ * `fetch`; a Node-side request is unaffected. The test server disables auth and
+ * xsrf (see `jupyter_server_test_config.py`), so no headers are needed.
+ */
+export async function seedAwareness(
+  page: IJupyterLabPageFixture,
+  path: string,
+  token: string
+): Promise<string> {
+  const baseUrl: string = await page.evaluate(
+    () => (window as any).jupyterapp.serviceManager.serverSettings.baseUrl
+  );
+  const res = await page.request.post(
+    `${baseUrl}jsd-test/seed-awareness?path=${encodeURIComponent(path)}&token=${encodeURIComponent(token)}`
+  );
+  if (!res.ok()) {
+    throw new Error(`seed-awareness -> HTTP ${res.status()}`);
+  }
+  const result = (await res.json()) as { peer_client_id: string };
+  return result.peer_client_id;
+}
+
+/**
+ * Reads the client-side awareness states of the open document at `path`,
+ * straight from the provider's `Awareness` (the same object the frontend uses
+ * to render remote cursors / personas). Returns a plain map keyed by the peer
+ * awareness client id, or `null` if the document/provider isn't found. Robust
+ * to virtualized DOM since it reads the shared model, not the view.
+ */
+export async function getClientAwareness(
+  page: IJupyterLabPageFixture,
+  path: string
+): Promise<Record<string, unknown> | null> {
+  return page.evaluate((p: string) => {
+    const app = (window as any).jupyterapp;
+    for (const widget of app.shell.widgets('main')) {
+      const context = (widget as any).context;
+      if (context?.path === p && context.model?.sharedModel?.awareness) {
+        const states = context.model.sharedModel.awareness.getStates();
+        const out: Record<string, unknown> = {};
+        for (const [clientId, state] of states.entries()) {
+          out[String(clientId)] = state;
+        }
+        return out;
+      }
+    }
+    return null;
+  }, path);
 }
 
 /**


### PR DESCRIPTION
Fixes #279

## Summary

A newly-connected or refreshed client is now sent the room's current awareness state as part of the sync handshake, instead of only learning about existing slots when a later change delta happens to re-touch them.

Awareness was previously broadcast solely as change deltas. A client that connected after a slot was published (e.g. a persona registering its awareness) would not see that slot until something mutated it again, which could take several seconds. This surfaces downstream in jupyter-ai-persona-manager as personas taking ~10s to appear on refresh (jupyter-ai-contrib/jupyter-ai-persona-manager#76).

## Technical details

In the SS1 handler, right after the SS2 reply (which already carries the current YDoc state) and before the SS1 request, the room encodes the full current awareness state and writes it to that client's socket alone. Grouping it with the SS2 reply means both "here's the server's current state" messages travel together and awareness reaches the client before we ask it for its own updates. It is not re-broadcast to peers that already hold the state, and it is sent only after mark_synced, so a desynced client mid-handshake never receives it.

## Testing

Backend integration tests in `test_yroom_sync.py` cover the FakeWebSocket handshake: a slot published before connect is delivered by the handshake alone, the snapshot reaches only the new client (not existing peers), and it arrives after the SS2 reply.

An end-to-end test (`ui-tests/awareness-on-connect.spec.ts`) exercises the real browser connect path that users hit on refresh: open a document, close it (the client disconnects but the room survives GC), publish a persona's awareness into the still-alive room while nothing is connected, then reopen — a fresh sync handshake, like a refresh. It asserts the persona appears in the reconnected client's awareness within 5s. This times out on `main` and passes with the fix. Backed by a test-only `/jsd-test/seed-awareness` endpoint.