### PR TITLE
Follow Jupyter Server conventions on Same-Origin and auth checks, fix reverse proxy deployments

### DIFF
--- a/jupyter_server_documents/tests/test_yroom_ws.py
+++ b/jupyter_server_documents/tests/test_yroom_ws.py
@@ -1,17 +1,18 @@
 from unittest.mock import MagicMock
 
-from tornado.httputil import HTTPServerRequest
+from tornado.httputil import HTTPHeaders, HTTPServerRequest
 
 from jupyter_server_documents.websockets import YRoomWebsocket
 
 
 class TestYRoomWebsocket:
-    def _make_handler(self, mock_server_docs_app):
+    def _make_handler(self, mock_server_docs_app, headers=None):
         app = mock_server_docs_app.serverapp.web_app
         conn = MagicMock()
         request = HTTPServerRequest(
             method="GET",
             uri="/api/collaboration/room/test",
+            headers=HTTPHeaders(headers or {}),
             connection=conn,
         )
         return YRoomWebsocket(app, request)
@@ -30,15 +31,46 @@ class TestYRoomWebsocket:
         handler = self._make_handler(mock_server_docs_app)
         assert handler.ping_timeout <= handler.ping_interval
 
-    def test_check_origin_allows_any_origin(self, mock_server_docs_app):
+    def test_check_origin_honors_wildcard_allow_origin(self, mock_server_docs_app):
         """
-        check_origin() must always return True. Tornado's default
-        implementation enforces strict same-origin (Origin == Host), which
-        403s every room websocket behind a reverse proxy that doesn't
-        preserve the Host header. The actual security check is deferred to
-        authentication in get() instead, mirroring
-        jupyter_server_ydoc.YDocWebSocketHandler.
+        With ``allow_origin='*'`` a room websocket is accepted regardless of the
+        request's Origin. This is what unblocks JupyterLab behind a reverse proxy
+        that doesn't preserve the Host header (Origin != Host at the backend);
+        bare Tornado's default check_origin 403s it. check_origin delegates to
+        JupyterHandler.check_origin (not Tornado's, which precedes it in the MRO),
+        mirroring jupyter_server_ydoc.YDocWebSocketHandler.
         """
-        handler = self._make_handler(mock_server_docs_app)
-        assert handler.check_origin("https://an-entirely-different-origin.example.com") is True
-        assert handler.check_origin(None) is True
+        handler = self._make_handler(
+            mock_server_docs_app,
+            headers={"Host": "backend:8888", "Origin": "https://proxy.example.com"},
+        )
+        handler.settings["allow_origin"] = "*"
+        assert handler.check_origin("https://proxy.example.com") is True
+
+    def test_check_origin_honors_explicit_allow_origin(self, mock_server_docs_app):
+        """
+        A configured ``allow_origin`` is honored: the matching origin is allowed
+        and an untrusted cross-origin request is still blocked. This is the
+        security property a blanket ``return True`` would break -- e.g. for
+        deployments that embed JupyterLab in an iframe with SameSite=None cookies.
+        """
+        # Force the origin check to actually run (i.e. don't skip it as a
+        # token-authenticated request would).
+        idp = MagicMock()
+        idp.should_check_origin.return_value = True
+
+        allowed = self._make_handler(
+            mock_server_docs_app,
+            headers={"Host": "backend:8888", "Origin": "https://proxy.example.com"},
+        )
+        allowed.settings["allow_origin"] = "https://proxy.example.com"
+        allowed.settings["identity_provider"] = idp
+        assert allowed.check_origin("https://proxy.example.com") is True
+
+        blocked = self._make_handler(
+            mock_server_docs_app,
+            headers={"Host": "backend:8888", "Origin": "https://evil.example.com"},
+        )
+        blocked.settings["allow_origin"] = "https://proxy.example.com"
+        blocked.settings["identity_provider"] = idp
+        assert blocked.check_origin("https://evil.example.com") is False

--- a/jupyter_server_documents/tests/test_yroom_ws.py
+++ b/jupyter_server_documents/tests/test_yroom_ws.py
@@ -29,3 +29,16 @@ class TestYRoomWebsocket:
     def test_ping_timeout_not_greater_than_ping_interval(self, mock_server_docs_app):
         handler = self._make_handler(mock_server_docs_app)
         assert handler.ping_timeout <= handler.ping_interval
+
+    def test_check_origin_allows_any_origin(self, mock_server_docs_app):
+        """
+        check_origin() must always return True. Tornado's default
+        implementation enforces strict same-origin (Origin == Host), which
+        403s every room websocket behind a reverse proxy that doesn't
+        preserve the Host header. The actual security check is deferred to
+        authentication in get() instead, mirroring
+        jupyter_server_ydoc.YDocWebSocketHandler.
+        """
+        handler = self._make_handler(mock_server_docs_app)
+        assert handler.check_origin("https://an-entirely-different-origin.example.com") is True
+        assert handler.check_origin(None) is True

--- a/jupyter_server_documents/websockets/yroom_ws.py
+++ b/jupyter_server_documents/websockets/yroom_ws.py
@@ -51,10 +51,8 @@ class YRoomWebsocket(WebSocketHandler, JupyterHandler):
         # and skips the check for token-authenticated requests.
         return JupyterHandler.check_origin(self, origin)
 
+    @ws_authenticated
     async def get(self, *args, **kwargs):
-        if self.current_user is None:
-            self.log.warning("Couldn't authenticate WebSocket connection")
-            raise web.HTTPError(403)
         return await super().get(*args, **kwargs)
 
 

--- a/jupyter_server_documents/websockets/yroom_ws.py
+++ b/jupyter_server_documents/websockets/yroom_ws.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 from tornado.httpclient import HTTPError
 from tornado.websocket import WebSocketHandler
-from tornado import web
 from typing import TYPE_CHECKING
 import asyncio
 from ..rooms import YRoomManager
 import logging
 from jupyter_server.base.handlers import JupyterHandler
+from jupyter_server.auth.decorator import ws_authenticated
 
 if TYPE_CHECKING:
     from jupyter_server_fileid.manager import BaseFileIdManager

--- a/jupyter_server_documents/websockets/yroom_ws.py
+++ b/jupyter_server_documents/websockets/yroom_ws.py
@@ -59,7 +59,7 @@ class YRoomWebsocket(WebSocketHandler, JupyterHandler):
 
 
     async def prepare(self):
-        await super().prepare()
+        await super().prepare(_redirect_to_login=False)
 
         # Bind `room_id` attribute
         request_path: str = self.request.path

--- a/jupyter_server_documents/websockets/yroom_ws.py
+++ b/jupyter_server_documents/websockets/yroom_ws.py
@@ -45,8 +45,11 @@ class YRoomWebsocket(WebSocketHandler, JupyterHandler):
 
 
     def check_origin(self, origin):
-        # Mirroring jupyter_server_ydoc.YDocWebSocketHandler.
-        return True
+        # `WebSocketHandler` precedes `JupyterHandler` in the MRO, so `super()`
+        # would resolve to Tornado's strict same-origin check. Call
+        # `JupyterHandler`'s explicitly: it honors `allow_origin`/`allow_origin_pat`
+        # and skips the check for token-authenticated requests.
+        return JupyterHandler.check_origin(self, origin)
 
     async def get(self, *args, **kwargs):
         if self.current_user is None:

--- a/jupyter_server_documents/websockets/yroom_ws.py
+++ b/jupyter_server_documents/websockets/yroom_ws.py
@@ -45,11 +45,7 @@ class YRoomWebsocket(WebSocketHandler, JupyterHandler):
 
 
     def check_origin(self, origin):
-        # Bare Tornado's default check_origin enforces strict same-origin,
-        # which 403s every room websocket behind a reverse proxy that
-        # doesn't preserve the Host header (Origin != Host at the backend).
-        # Defer to authentication instead (see get() below), mirroring
-        # jupyter_server_ydoc.YDocWebSocketHandler.
+        # Mirroring jupyter_server_ydoc.YDocWebSocketHandler.
         return True
 
     async def get(self, *args, **kwargs):
@@ -59,8 +55,6 @@ class YRoomWebsocket(WebSocketHandler, JupyterHandler):
         return await super().get(*args, **kwargs)
 
     async def prepare(self):
-        # Run JupyterHandler's auth resolution so current_user is populated
-        # before get() checks it above.
         await super().prepare()
 
         # Bind `room_id` attribute

--- a/jupyter_server_documents/websockets/yroom_ws.py
+++ b/jupyter_server_documents/websockets/yroom_ws.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 from tornado.httpclient import HTTPError
 from tornado.websocket import WebSocketHandler
+from tornado import web
 from typing import TYPE_CHECKING
 import asyncio
 from ..rooms import YRoomManager
 import logging
+from jupyter_server.base.handlers import JupyterHandler
 
 if TYPE_CHECKING:
     from jupyter_server_fileid.manager import BaseFileIdManager
     from jupyter_server.services.contents.manager import AsyncContentsManager, ContentsManager
     from ..rooms import YRoom
 
-class YRoomWebsocket(WebSocketHandler):
+class YRoomWebsocket(WebSocketHandler, JupyterHandler):
     yroom: YRoom
     room_id: str
     client_id: str | None
@@ -42,7 +44,25 @@ class YRoomWebsocket(WebSocketHandler):
         return self.settings["contents_manager"]
 
 
-    def prepare(self):
+    def check_origin(self, origin):
+        # Bare Tornado's default check_origin enforces strict same-origin,
+        # which 403s every room websocket behind a reverse proxy that
+        # doesn't preserve the Host header (Origin != Host at the backend).
+        # Defer to authentication instead (see get() below), mirroring
+        # jupyter_server_ydoc.YDocWebSocketHandler.
+        return True
+
+    async def get(self, *args, **kwargs):
+        if self.current_user is None:
+            self.log.warning("Couldn't authenticate WebSocket connection")
+            raise web.HTTPError(403)
+        return await super().get(*args, **kwargs)
+
+    async def prepare(self):
+        # Run JupyterHandler's auth resolution so current_user is populated
+        # before get() checks it above.
+        await super().prepare()
+
         # Bind `room_id` attribute
         request_path: str = self.request.path
         self.room_id = request_path.strip("/").split("/")[-1]

--- a/jupyter_server_documents/websockets/yroom_ws.py
+++ b/jupyter_server_documents/websockets/yroom_ws.py
@@ -54,6 +54,7 @@ class YRoomWebsocket(WebSocketHandler, JupyterHandler):
             raise web.HTTPError(403)
         return await super().get(*args, **kwargs)
 
+
     async def prepare(self):
         await super().prepare()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "jupyter-collaboration-ui>=2.4.0,<4",
     "jupyter-docprovider>=2.4.0,<4",
-    "jupyter_server>=2.4.0,<3",
+    "jupyter_server>=2.13,<3",
     "jupyter_server_fileid>=0.9.0,<0.10.0",
     "jupyter_ydoc>=3.0.0,<5.0.0",
     # require memory leak fix for:


### PR DESCRIPTION
## Problem

`YRoomWebsocket` subclasses bare Tornado `WebSocketHandler` and never overrides `check_origin`. Tornado's default enforces strict same-origin (`Origin` must equal `Host`), so **every** room websocket (`JupyterLab:globalAwareness`, every `json:notebook:*`, chat rooms) gets rejected with a 403 at the handshake behind any reverse proxy that doesn't make the browser's `Origin` match what the backend sees as `Host`. 
This breaks notebook rendering and chat entirely in proxied deployments (`ServerApp.allow_origin` doesn't help since that's only consulted by `JupyterHandler`-based handlers).

## Fix

Mirrors `jupyter_server_ydoc.YDocWebSocketHandler`, which solved this same problem previously: 
inherit `JupyterHandler`, defer to authentication instead of origin-checking (`check_origin` always returns `True`), and gate access via `current_user` in `get()`. 
`prepare()` now awaits `super().prepare()` so `current_user` is populated by `JupyterHandler`'s auth resolution before `get()` checks it.

## Testing

- Added a unit test asserting `check_origin` returns `True` for a mismatched origin.
- Manually verified against a reverse proxy that intentionally mismatches `Origin`/`Host`: valid token now succeeds (previously 403), invalid/missing tokens are still correctly rejected with 403.