### PR TITLE
Skip redundant saves when rooms are stopped

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -1116,10 +1116,13 @@ class YRoom(LoggingConfigurable):
             # interruptible write that can corrupt the file if the server is
             # stopped uncleanly (e.g. a misconfigured environment).
             if not immediately and self.file_api.has_unsaved_changes:
+                self.log.info(f"Saving YRoom '{self.room_id}' on stop; it has unsaved changes.")
                 prev_jupyter_ydoc = self._jupyter_ydoc
                 self._save_task = asyncio.create_task(
                     self.file_api.save(prev_jupyter_ydoc)
                 )
+            elif not immediately:
+                self.log.info(f"Skipping redundant save-on-stop for YRoom '{self.room_id}'; no unsaved changes.")
 
         # Fire `on_stop` callbacks. Sync callbacks run immediately; coroutines
         # returned by async callbacks are collected so they can be awaited (in

--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -1093,6 +1093,11 @@ class YRoom(LoggingConfigurable):
                     msg_type = message[0]
                     if msg_type == YMessageType.SYNC and len(message) >= 2 and message[1] == YSyncMessageSubtype.SYNC_UPDATE:
                         self.handle_sync_update(client_id, message)
+                        # Observers were removed above, so applying this update
+                        # will not schedule a save on its own. Mark the room
+                        # dirty so the final save-on-close below is not skipped.
+                        if self.file_api:
+                            self.file_api.schedule_save()
                     elif msg_type == YMessageType.AWARENESS:
                         self.handle_awareness_update(client_id, message)
                 self._message_queue.task_done()
@@ -1104,7 +1109,13 @@ class YRoom(LoggingConfigurable):
         # previous content if `immediately=False`.
         if self.file_api and self._jupyter_ydoc:
             self.file_api.stop()
-            if not immediately:
+            # Only perform the final save-on-close when there are unsaved
+            # changes. The autosave loop persists edits as they happen, so this
+            # final save is usually redundant -- and every save truncates and
+            # rewrites the file. Skipping the redundant save removes an
+            # interruptible write that can corrupt the file if the server is
+            # stopped uncleanly (e.g. a misconfigured environment).
+            if not immediately and self.file_api.has_unsaved_changes:
                 prev_jupyter_ydoc = self._jupyter_ydoc
                 self._save_task = asyncio.create_task(
                     self.file_api.save(prev_jupyter_ydoc)

--- a/jupyter_server_documents/rooms/yroom_file_api.py
+++ b/jupyter_server_documents/rooms/yroom_file_api.py
@@ -622,22 +622,15 @@ class YRoomFileAPI(LoggingConfigurable):
             # Build arguments to `CM.save()`
             path = self.get_path()
             content = jupyter_ydoc.source
-            # Guard against truncating a notebook to a pristine/uninitialized
-            # document. A notebook's source is a dict, and a not-yet-loaded
-            # YNotebook has nbformat == 0 (real notebooks are >= 4) -- a state a
-            # user cannot reach by editing. Saving it would overwrite good
-            # on-disk content with an empty notebook, so skip and warn instead.
-            # We match only nbformat == 0 (not a missing key) so we never skip a
-            # save of content that could be real.
-            if (
-                self.file_type == "notebook"
-                and isinstance(content, dict)
-                and content.get("nbformat") == 0
-            ):
+            # Guard against truncating a notebook: skip the save when the
+            # notebook content is empty (an empty `{}` document). Saving that
+            # would overwrite good on-disk content with a 0-byte / empty
+            # notebook. This only blocks the destructive save; an empty `{}`
+            # file is still openable.
+            if self.file_type == "notebook" and not content:
                 self.log.warning(
-                    f"Refusing to save room '{self.room_id}': notebook is empty or "
-                    "uninitialized (nbformat == 0). Skipping the save to avoid "
-                    "truncating the file on disk."
+                    f"Refusing to save room '{self.room_id}': notebook content is empty. "
+                    "Skipping the save to avoid truncating the file on disk."
                 )
                 return
             file_format = self.file_format

--- a/jupyter_server_documents/rooms/yroom_file_api.py
+++ b/jupyter_server_documents/rooms/yroom_file_api.py
@@ -404,6 +404,16 @@ class YRoomFileAPI(LoggingConfigurable):
             result in only a single save operation.
         """
         self._save_scheduled = True
+
+    @property
+    def has_unsaved_changes(self) -> bool:
+        """Whether the YDoc has changes not yet persisted to disk.
+
+        `True` when a save has been scheduled via `schedule_save()` but has not
+        yet completed successfully. `YRoom.stop()` uses this to skip a redundant
+        final save when the autosave loop has already persisted every change.
+        """
+        return self._save_scheduled
     
     async def _watch_file(self, jupyter_ydoc: YBaseDoc) -> None:
         """Background task that monitors the file and processes scheduled saves.
@@ -664,6 +674,9 @@ class YRoomFileAPI(LoggingConfigurable):
         except Exception as e:
             self.log.error("An exception occurred when saving JupyterYDoc.")
             self.log.exception(e)
+            # Re-arm the save flag so a failed save is retried and is not
+            # mistaken for "no unsaved changes" by `has_unsaved_changes`.
+            self._save_scheduled = True
     
 
     def stop(self) -> None:

--- a/jupyter_server_documents/rooms/yroom_file_api.py
+++ b/jupyter_server_documents/rooms/yroom_file_api.py
@@ -622,6 +622,23 @@ class YRoomFileAPI(LoggingConfigurable):
             # Build arguments to `CM.save()`
             path = self.get_path()
             content = jupyter_ydoc.source
+            # Guard against truncating a notebook to an empty/uninitialized
+            # document. A notebook's source is a dict; a pristine or not-yet-
+            # loaded YNotebook has nbformat == 0 (real notebooks are >= 4), a
+            # state a user cannot reach by editing. Saving empty/uninitialized
+            # content would overwrite good on-disk content with a 0-byte or
+            # invalid notebook, so skip the save and warn instead.
+            if self.file_type == "notebook" and (
+                not content
+                or (isinstance(content, dict) and not content.get("nbformat"))
+            ):
+                nbformat_version = content.get("nbformat") if isinstance(content, dict) else None
+                self.log.warning(
+                    f"Refusing to save room '{self.room_id}': notebook content is empty "
+                    f"or uninitialized (nbformat={nbformat_version!r}). Skipping the save "
+                    "to avoid truncating the file on disk."
+                )
+                return
             file_format = self.file_format
             file_type = self.file_type if self.file_type in SAVEABLE_FILE_TYPES else "file"
 

--- a/jupyter_server_documents/rooms/yroom_file_api.py
+++ b/jupyter_server_documents/rooms/yroom_file_api.py
@@ -622,21 +622,22 @@ class YRoomFileAPI(LoggingConfigurable):
             # Build arguments to `CM.save()`
             path = self.get_path()
             content = jupyter_ydoc.source
-            # Guard against truncating a notebook to an empty/uninitialized
-            # document. A notebook's source is a dict; a pristine or not-yet-
-            # loaded YNotebook has nbformat == 0 (real notebooks are >= 4), a
-            # state a user cannot reach by editing. Saving empty/uninitialized
-            # content would overwrite good on-disk content with a 0-byte or
-            # invalid notebook, so skip the save and warn instead.
-            if self.file_type == "notebook" and (
-                not content
-                or (isinstance(content, dict) and not content.get("nbformat"))
+            # Guard against truncating a notebook to a pristine/uninitialized
+            # document. A notebook's source is a dict, and a not-yet-loaded
+            # YNotebook has nbformat == 0 (real notebooks are >= 4) -- a state a
+            # user cannot reach by editing. Saving it would overwrite good
+            # on-disk content with an empty notebook, so skip and warn instead.
+            # We match only nbformat == 0 (not a missing key) so we never skip a
+            # save of content that could be real.
+            if (
+                self.file_type == "notebook"
+                and isinstance(content, dict)
+                and content.get("nbformat") == 0
             ):
-                nbformat_version = content.get("nbformat") if isinstance(content, dict) else None
                 self.log.warning(
-                    f"Refusing to save room '{self.room_id}': notebook content is empty "
-                    f"or uninitialized (nbformat={nbformat_version!r}). Skipping the save "
-                    "to avoid truncating the file on disk."
+                    f"Refusing to save room '{self.room_id}': notebook is empty or "
+                    "uninitialized (nbformat == 0). Skipping the save to avoid "
+                    "truncating the file on disk."
                 )
                 return
             file_format = self.file_format

--- a/jupyter_server_documents/tests/test_empty_notebook_save_guard.py
+++ b/jupyter_server_documents/tests/test_empty_notebook_save_guard.py
@@ -66,6 +66,6 @@ async def test_save_skips_empty_uninitialized_notebook(tmp_path, caplog):
     # The good on-disk notebook must be left untouched (not truncated).
     assert nb_path.read_text() == GOOD_NB
     assert any(
-        "notebook content is empty or uninitialized" in r.getMessage()
+        "uninitialized (nbformat == 0)" in r.getMessage()
         for r in caplog.records
     )

--- a/jupyter_server_documents/tests/test_empty_notebook_save_guard.py
+++ b/jupyter_server_documents/tests/test_empty_notebook_save_guard.py
@@ -1,8 +1,8 @@
-"""Tests for the empty/uninitialized-notebook save guard in `YRoomFileAPI.save()`.
+"""Tests for the empty-notebook save guard in `YRoomFileAPI.save()`.
 
-A notebook's YDoc source is a dict; a pristine or not-yet-loaded `YNotebook` has
-`nbformat == 0`. Saving that would overwrite good on-disk content with an empty
-notebook, so `save()` must skip the write (and warn) instead of truncating.
+If a notebook room's YDoc source is empty (an empty ``{}`` document), saving it
+would overwrite good on-disk content with a 0-byte / empty notebook. `save()`
+must skip the write (and warn) instead of truncating.
 """
 import logging
 
@@ -20,9 +20,9 @@ GOOD_NB = (
 )
 
 
-class _UninitializedNotebook:
-    """Stand-in for a pristine/unloaded YNotebook (nbformat == 0)."""
-    source = {"cells": [], "metadata": {}, "nbformat": 0, "nbformat_minor": 0}
+class _EmptyNotebook:
+    """Stand-in for an empty/unloaded YNotebook whose source is ``{}``."""
+    source = {}
     dirty = True
 
 
@@ -57,15 +57,14 @@ def _make_notebook_file_api(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_save_skips_empty_uninitialized_notebook(tmp_path, caplog):
+async def test_save_skips_empty_notebook(tmp_path, caplog):
     file_api, nb_path = _make_notebook_file_api(tmp_path)
 
     with caplog.at_level(logging.WARNING):
-        await file_api.save(_UninitializedNotebook())
+        await file_api.save(_EmptyNotebook())
 
     # The good on-disk notebook must be left untouched (not truncated).
     assert nb_path.read_text() == GOOD_NB
     assert any(
-        "uninitialized (nbformat == 0)" in r.getMessage()
-        for r in caplog.records
+        "notebook content is empty" in r.getMessage() for r in caplog.records
     )

--- a/jupyter_server_documents/tests/test_empty_notebook_save_guard.py
+++ b/jupyter_server_documents/tests/test_empty_notebook_save_guard.py
@@ -1,0 +1,71 @@
+"""Tests for the empty/uninitialized-notebook save guard in `YRoomFileAPI.save()`.
+
+A notebook's YDoc source is a dict; a pristine or not-yet-loaded `YNotebook` has
+`nbformat == 0`. Saving that would overwrite good on-disk content with an empty
+notebook, so `save()` must skip the write (and warn) instead of truncating.
+"""
+import logging
+
+import pytest
+from traitlets.config import LoggingConfigurable
+from jupyter_server.services.contents.filemanager import AsyncFileContentsManager
+from jupyter_server_fileid.manager import ArbitraryFileIdManager
+
+from ..rooms import YRoomFileAPI
+
+GOOD_NB = (
+    '{"cells": [{"cell_type": "code", "source": "1 + 1", "metadata": {}, '
+    '"outputs": [], "execution_count": null}], "metadata": {}, '
+    '"nbformat": 4, "nbformat_minor": 5}'
+)
+
+
+class _UninitializedNotebook:
+    """Stand-in for a pristine/unloaded YNotebook (nbformat == 0)."""
+    source = {"cells": [], "metadata": {}, "nbformat": 0, "nbformat_minor": 0}
+    dirty = True
+
+
+def _make_notebook_file_api(tmp_path):
+    contents_manager = AsyncFileContentsManager(
+        root_dir=str(tmp_path), use_atomic_writing=True
+    )
+    fileid_manager = ArbitraryFileIdManager(db_path=str(tmp_path / "file_id_manager.db"))
+    nb_path = tmp_path / "n.ipynb"
+    nb_path.write_text(GOOD_NB)
+    file_id = fileid_manager.index("n.ipynb")
+    room_id = f"json:notebook:{file_id}"
+
+    class MockYRoom(LoggingConfigurable):
+        @property
+        def fileid_manager(self):
+            return fileid_manager
+
+        @property
+        def contents_manager(self):
+            return contents_manager
+
+        @property
+        def outputs_manager(self):
+            return None
+
+        @property
+        def room_id(self):
+            return room_id
+
+    return YRoomFileAPI(parent=MockYRoom()), nb_path
+
+
+@pytest.mark.asyncio
+async def test_save_skips_empty_uninitialized_notebook(tmp_path, caplog):
+    file_api, nb_path = _make_notebook_file_api(tmp_path)
+
+    with caplog.at_level(logging.WARNING):
+        await file_api.save(_UninitializedNotebook())
+
+    # The good on-disk notebook must be left untouched (not truncated).
+    assert nb_path.read_text() == GOOD_NB
+    assert any(
+        "notebook content is empty or uninitialized" in r.getMessage()
+        for r in caplog.records
+    )

--- a/jupyter_server_documents/tests/test_stop_save_guard.py
+++ b/jupyter_server_documents/tests/test_stop_save_guard.py
@@ -1,0 +1,39 @@
+"""Tests for the save-on-close guard in `YRoom.stop()`.
+
+A graceful stop should only perform the final save when the document has
+unsaved changes. The autosave loop already persists edits as they happen, so an
+unconditional final save is usually redundant -- and each save is an
+interruptible truncate+write. Skipping the redundant save avoids a needless
+write window without dropping real changes.
+"""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_stop_skips_save_when_no_unsaved_changes(make_yroom):
+    """A clean room (everything already persisted) schedules no final save."""
+    room = await make_yroom(file_type="file")
+
+    # After loading, the autosave loop has nothing pending.
+    assert room.file_api.has_unsaved_changes is False
+
+    room.stop(immediately=False)
+
+    # No redundant save-on-close was scheduled.
+    assert room._save_task is None
+    await room.until_saved  # resolves immediately; must not hang
+
+
+@pytest.mark.asyncio
+async def test_stop_saves_when_unsaved_changes(make_yroom):
+    """A room with pending changes performs the final save-on-close."""
+    room = await make_yroom(file_type="file")
+
+    # Simulate an edit that scheduled a save the autosave loop has not yet run.
+    room.file_api.schedule_save()
+    assert room.file_api.has_unsaved_changes is True
+
+    room.stop(immediately=False)
+
+    assert room._save_task is not None
+    await room.until_saved


### PR DESCRIPTION
## Motivation

If a server is forcibly stopped while it is shutting down, active files can be truncated to 0 bytes, generating a `.invalid` sidecar file as well. This is because "pulling out the power cord" in the middle of a file write is not guaranteed to be atomically safe on all systems. We are still actively investigating exactly what scenarios allow for this.

One factor that contributes to the impact of this issue is that `YRoom.stop()` always performs a final save even when autosave has already persisted everything.

## Summary

Adds two stopgap protections around saving on stop:

1. The final save on a graceful stop now runs only when the document has unsaved changes. Edits made just before the stop, and updates applied while draining the message queue during stop, are still saved; the common already-persisted case is skipped.

2. A notebook save is skipped (with a warning) when its content is empty (0B). This should never happen, but this is being included regardless as an additional safety measure.

The save-on-stop decision (saved vs skipped) is now logged to aid debugging.

To be clear: this feature is not a bug and this PR is not the sole fix. Saving on room stop is intended behavior to prevent data loss, and admins must avoid forcibly killing the server while it is still cleaning up resources (at least for 30 seconds). This PR just minimizes the frequency of saving on room stop to reduce harm done to admins who have improperly configured deployments.

## Technical details

Adds `YRoomFileAPI.has_unsaved_changes` (backed by the existing save-scheduled flag) and gates the final save in `YRoom.stop()` on it. The stop drain applies updates after observers are removed, so it now marks the room dirty to keep those saved; a failed save re-arms the flag so it is retried rather than treated as clean.

## Testing

Added regression tests for the stop-save gate and the empty-notebook guard.