### PR TITLE
Fix exception when a room is stopped before it finishes starting

### DIFF
--- a/jupyter_server_documents/rooms/yroom.py
+++ b/jupyter_server_documents/rooms/yroom.py
@@ -1061,8 +1061,16 @@ class YRoom(LoggingConfigurable):
         # Disconnect all clients with the given close code
         self.clients.stop(close_code=close_code)
         
-        # Stop awareness heartbeat
-        asyncio.create_task(self._awareness.stop())
+        # Stop awareness heartbeat. Guard against stopping a room that never
+        # finished starting (e.g. stopped during the initial load): awareness
+        # may not have been started, and `Awareness.stop()` raises "Awareness
+        # not started", which would surface as an unretrieved task exception.
+        async def _stop_awareness() -> None:
+            try:
+                await self._awareness.stop()
+            except RuntimeError:
+                pass
+        asyncio.create_task(_stop_awareness())
 
         # Remove all observers
         try:

--- a/jupyter_server_documents/rooms/yroom_file_api.py
+++ b/jupyter_server_documents/rooms/yroom_file_api.py
@@ -151,6 +151,10 @@ class YRoomFileAPI(LoggingConfigurable):
         self._last_modified = None
         self._stopped = False
         self._is_writable = True
+        # Initialized here (not only at the end of `_load_content`) so `stop()`
+        # is safe when a room is stopped before the initial content load has
+        # started the watch-file task. Otherwise `stop()` raises AttributeError.
+        self._watch_file_task = None
 
         # Initialize content-related primitives
         self._content_loading = False

--- a/jupyter_server_documents/tests/test_stop_before_load.py
+++ b/jupyter_server_documents/tests/test_stop_before_load.py
@@ -1,0 +1,47 @@
+"""Regression test: stopping a YRoomFileAPI before the initial load must not raise.
+
+If a room is stopped before `_load_content()` has started the watch-file task,
+`stop()` used to raise ``AttributeError: 'YRoomFileAPI' object has no attribute
+'_watch_file_task'``, which broke `YRoomManager.delete_room`.
+"""
+from traitlets.config import LoggingConfigurable
+from jupyter_server.services.contents.filemanager import AsyncFileContentsManager
+from jupyter_server_fileid.manager import ArbitraryFileIdManager
+
+from ..rooms import YRoomFileAPI
+
+
+def _make_notebook_file_api(tmp_path):
+    contents_manager = AsyncFileContentsManager(
+        root_dir=str(tmp_path), use_atomic_writing=True
+    )
+    fileid_manager = ArbitraryFileIdManager(db_path=str(tmp_path / "file_id_manager.db"))
+    (tmp_path / "n.ipynb").write_text("{}")
+    file_id = fileid_manager.index("n.ipynb")
+    room_id = f"json:notebook:{file_id}"
+
+    class MockYRoom(LoggingConfigurable):
+        @property
+        def fileid_manager(self):
+            return fileid_manager
+
+        @property
+        def contents_manager(self):
+            return contents_manager
+
+        @property
+        def outputs_manager(self):
+            return None
+
+        @property
+        def room_id(self):
+            return room_id
+
+    return YRoomFileAPI(parent=MockYRoom())
+
+
+def test_stop_before_load_does_not_raise(tmp_path):
+    file_api = _make_notebook_file_api(tmp_path)
+    # No content has been loaded, so the watch-file task was never started.
+    file_api.stop()  # must not raise AttributeError
+    assert file_api.stopped is True


### PR DESCRIPTION
## Motivation

`YRoomManager.delete_room` raises an exception during shutdown when a room is stopped before it finishes starting. `YRoomFileAPI.stop()` raises `AttributeError` on `_watch_file_task` (only assigned at the end of `_load_content`), and `Awareness.stop()` raises `Awareness not started`. Both leave the room half torn down and surface as errors from `YRoomManager.stop()`.

## Summary

Initialize `_watch_file_task` in `YRoomFileAPI.__init__` so `stop()` is safe before the first content load, and guard the awareness stop in `YRoom.stop()` against the not-started case. A room stopped mid-startup now tears down cleanly.

## Technical details

The empty/uninitialized-document save that this crash previously masked is already prevented by the final-save gate on `has_unsaved_changes` and the empty-notebook save guard, so initializing the attribute is safe.

## Testing

Added a regression test asserting `stop()` before the initial load does not raise.