### PR TITLE
[Feature] Order execute requests by a monotonic per-client sequence

### DIFF
--- a/jupyter_server_documents/execution_handlers.py
+++ b/jupyter_server_documents/execution_handlers.py
@@ -3,7 +3,12 @@ from jupyter_server.base.handlers import APIHandler
 from tornado import web
 from tornado.escape import json_encode
 
-from .rooms.ynotebook_room import YNotebookRoom, SourceMismatchError, PredecessorTimeoutError
+from .rooms.ynotebook_room import (
+    YNotebookRoom,
+    SourceMismatchError,
+    SequenceOutOfRangeError,
+    SessionResetError,
+)
 
 
 AUTH_RESOURCE = "executions"
@@ -32,9 +37,9 @@ class KernelExecuteHandler(ExecutionsAPIHandler):
       ],
 
       // Execution ordering (optional)
-      "client_id":          "string",  // document client ID
-      "request_id":         "string",  // UUID for this request
-      "previous_request_id":"string"   // wait for this request to be enqueued first
+      "client_id": "string",  // identifies the browser tab; scopes `sequence`
+      "sequence":  0,         // monotonic counter per client_id, starts at 0
+      "request_id":"string"   // opaque UUID for logging / tracing
     }
     ```
 
@@ -51,8 +56,8 @@ class KernelExecuteHandler(ExecutionsAPIHandler):
     ## Responses
     - ``200 null``  — accepted (fire-and-forget)
     - ``400``       — bad request
-    - ``408``       — predecessor request timed out
     - ``409 {"error": "source_mismatch", "cell_id": "..."}`` — source diverged
+    - ``409``       — session reset (client should clear its counter and retry with sequence=0)
     """
 
     @web.authenticated
@@ -70,7 +75,13 @@ class KernelExecuteHandler(ExecutionsAPIHandler):
 
         client_id = body.get("client_id")
         request_id = body.get("request_id")
-        previous_request_id = body.get("previous_request_id")
+        sequence = body.get("sequence")
+
+        if sequence is not None:
+            if not isinstance(sequence, int) or sequence < 0:
+                raise web.HTTPError(400, "sequence must be a non-negative integer")
+            if not client_id:
+                raise web.HTTPError(400, "client_id is required when sequence is present")
 
         yroom = self.settings["yroom_manager"].get_room(document_id)
         if yroom is None:
@@ -83,14 +94,19 @@ class KernelExecuteHandler(ExecutionsAPIHandler):
                 cells_payload,
                 clear_outputs=True,
                 request_id=request_id,
-                previous_request_id=previous_request_id,
+                client_id=client_id,
+                sequence=sequence,
             )
         except SourceMismatchError as e:
             self.set_status(409)
             self.finish(json_encode({"error": "source_mismatch", "cell_id": e.cell_id}))
             return
-        except PredecessorTimeoutError:
-            raise web.HTTPError(408, "Timed out waiting for previous_request_id to be enqueued")
+        except SessionResetError:
+            self.set_status(409)
+            self.finish(json_encode({"error": "session_reset"}))
+            return
+        except SequenceOutOfRangeError as e:
+            raise web.HTTPError(400, str(e))
         except (LookupError, ValueError, RuntimeError) as e:
             raise web.HTTPError(400, str(e))
 

--- a/jupyter_server_documents/rooms/ynotebook_room.py
+++ b/jupyter_server_documents/rooms/ynotebook_room.py
@@ -21,10 +21,6 @@ if TYPE_CHECKING:
     from ..outputs.output_processor import OutputProcessor
 
 
-# How long a request with previous_request_id will wait for its predecessor.
-_PREDECESSOR_TIMEOUT = 10.0
-
-
 def _source_hash(source: str) -> str:
     """MurmurHash2 of the UTF-8 encoded source, seeded with 0.
 
@@ -72,8 +68,21 @@ class SourceMismatchError(Exception):
         self.cell_id = cell_id
 
 
-class PredecessorTimeoutError(Exception):
-    """Timed out waiting for previous_request_id to be enqueued."""
+class SequenceOutOfRangeError(Exception):
+    """A request arrived with a sequence number below the expected next value.
+
+    Raised when the client either duplicated a request or somehow rewound
+    without signalling a session reset (``sequence == 0``).
+    """
+
+
+class SessionResetError(Exception):
+    """A pending sequence wait was abandoned because the client session was reset.
+
+    Signalled when the browser sent ``sequence == 0`` while the server was
+    already tracking a higher sequence for that ``client_id``, or when the
+    kernel was disconnected mid-wait.
+    """
 
 
 @dataclass
@@ -105,10 +114,14 @@ class YNotebookRoom(YRoom):
         self._execution_queue: asyncio.Queue | None = None
         self._execution_worker_task: asyncio.Task | None = None
         self.output_processor: OutputProcessor | None = None
-        # Per-request ordering: maps request_id → Event that is set once the
-        # request has been enqueued.  Lets a successor wait for its predecessor
-        # without blocking the event loop.
-        self._enqueued_events: dict[str, asyncio.Event] = {}
+        # Per-client sequence-based ordering for execute_cells.
+        # _next_seq[client_id] is the next sequence number expected to be
+        # enqueued for that client. _seq_generation[client_id] is bumped on
+        # session reset so orphaned waiters can abandon. _seq_cv coordinates
+        # all waiters.
+        self._next_seq: dict[str, int] = {}
+        self._seq_generation: dict[str, int] = {}
+        self._seq_cv: asyncio.Condition = asyncio.Condition()
 
     # ── Kernel client lifecycle ───────────────────────────────────────────────────
 
@@ -144,8 +157,17 @@ class YNotebookRoom(YRoom):
         # pyzmq asyncio recv cancellation issues inside asyncio Tasks.
         await self._fetch_kernel_info()
 
-    async def disconnect_kernel(self) -> None:
-        """Detach from the kernel. Cancels the execution worker and drains the queue."""
+    async def disconnect_kernel(self, *, reset_sequences: bool = True) -> None:
+        """Detach from the kernel. Cancels the execution worker and drains the queue.
+
+        Parameters
+        ----------
+        reset_sequences:
+            When True (default), per-client sequence state is cleared and
+            pending waiters are abandoned with :class:`SessionResetError`.
+            Pass False to preserve the counter (in-place restart, where the
+            kernel_id — and thus the caller's counter — is unchanged).
+        """
         if self._kernel_manager is not None:
             try:
                 self._kernel_manager.remove_restart_callback(self._on_kernel_restart, "restart")
@@ -180,15 +202,23 @@ class YNotebookRoom(YRoom):
 
         self._kernel_manager = None
         self._shell_confirmed = False
-        # Clear the request-ordering state so stale pre-disconnect events
-        # don't linger and consume memory across sessions.
-        self._enqueued_events.clear()
+        if reset_sequences:
+            # Clear per-client sequence state and abandon any in-flight waiters
+            # by bumping every client's generation counter. Waiters check
+            # generation on wake and raise SessionResetError if it changed.
+            async with self._seq_cv:
+                for client_id in list(self._seq_generation.keys()):
+                    self._seq_generation[client_id] = self._seq_generation[client_id] + 1
+                self._next_seq.clear()
+                self._seq_cv.notify_all()
 
     async def _on_kernel_restart(self) -> None:
         # Save the kernel manager before disconnect_kernel() nulls it out,
         # so we can pass it back to connect_kernel() below.
         km = self._kernel_manager
-        await self.disconnect_kernel()
+        # In-place restart keeps the same kernel_id, so the caller's per-kernel
+        # sequence counter is still valid — preserve it across the reconnect.
+        await self.disconnect_kernel(reset_sequences=False)
         if km is not None:
             await self.connect_kernel(km)
 
@@ -380,7 +410,8 @@ class YNotebookRoom(YRoom):
         cells: list,
         clear_outputs: bool = False,
         request_id: Optional[str] = None,
-        previous_request_id: Optional[str] = None,
+        client_id: Optional[str] = None,
+        sequence: Optional[int] = None,
     ) -> None:
         """Enqueue a batch of cells atomically and return immediately.
 
@@ -388,6 +419,23 @@ class YNotebookRoom(YRoom):
         returns, so no other request can interleave with the batch.  This
         makes "Run All" safe against concurrent single-cell requests from
         other users — see davidbrochart's comment in PR #248.
+
+        Cross-request ordering
+        ----------------------
+        ``execute_cells`` is invoked from an HTTP POST endpoint, so concurrent
+        requests can arrive in any order — HTTP/2 streams and independent
+        HTTP/1.1 connections make no ordering promise. To preserve the browser's
+        intended order, callers pass a ``(client_id, sequence)`` pair.
+        ``sequence`` is a monotonic counter per ``client_id``; the server
+        enqueues in sequence order, buffering out-of-order arrivals until their
+        predecessors show up. This is deterministic — there is no timeout
+        heuristic.
+
+        Session reset: a request with ``sequence == 0`` when the server has
+        already seen higher sequences for that client_id signals the browser has
+        restarted its counter (new tab, kernel swap, explicit reset). The server
+        clears state and abandons pending waiters for that client_id with
+        ``SessionResetError``.
 
         Args:
             cells: List of dicts with keys:
@@ -397,70 +445,134 @@ class YNotebookRoom(YRoom):
                   Returns 409 for the first cell whose source has diverged;
                   no cells are enqueued.
 
-            request_id: UUID for this batch.  Set after all cells are enqueued
-                so a chained successor waits for the whole batch, not just the
-                first cell.
-
-            previous_request_id: Wait for this predecessor batch to be fully
-                enqueued before enqueuing any cell in this batch.
+            request_id: UUID for this batch (opaque; used for logging only).
+            client_id: Identifies the browser tab; scopes ``sequence``.
+            sequence: Monotonic counter per ``client_id``, starting at 0.
         """
         if self._kernel_client is None:
             raise RuntimeError("YNotebookRoom is not connected to a kernel")
         if self._execution_queue is None:
             raise RuntimeError("YNotebookRoom execution worker is not running")
 
-        # Wait for predecessor batch to finish enqueuing.
-        if previous_request_id:
-            if previous_request_id not in self._enqueued_events:
-                self._enqueued_events[previous_request_id] = asyncio.Event()
-            event = self._enqueued_events[previous_request_id]
-            try:
-                await asyncio.wait_for(event.wait(), timeout=_PREDECESSOR_TIMEOUT)
-            except asyncio.TimeoutError:
-                self._enqueued_events.pop(previous_request_id, None)
-                raise PredecessorTimeoutError()
-            self._enqueued_events.pop(previous_request_id, None)
+        acquired_seq = False
+        if client_id is not None and sequence is not None:
+            await self._wait_for_seq_turn(client_id, sequence)
+            acquired_seq = True
 
-        ydoc = await self.get_jupyter_ydoc()
-        file_id = self.room_id.split(":", 2)[2]
+        try:
+            ydoc = await self.get_jupyter_ydoc()
+            file_id = self.room_id.split(":", 2)[2]
 
-        # Resolve and verify ALL cells before touching any state, so a hash
-        # mismatch leaves the notebook completely unchanged.
-        items = []
-        for entry in cells:
-            cell_id = entry.get("cell_id") or entry  # accept plain string too
-            if not isinstance(cell_id, str):
-                raise ValueError(f"Each cell entry must have a cell_id string, got {entry!r}")
-            source_hash = entry.get("source_hash") if isinstance(entry, dict) else None
-            if source_hash is None:
-                raise ValueError(f"source_hash is required for cell {cell_id!r}")
-            ycell = self._find_kernel_cell(ydoc, cell_id)
-            current_source = str(ycell.get("source", ""))
-            if _source_hash(current_source) != source_hash:
-                raise SourceMismatchError(cell_id)
-            items.append((cell_id, ycell))
+            # Resolve and verify ALL cells before touching any state, so a hash
+            # mismatch leaves the notebook completely unchanged.
+            items = []
+            for entry in cells:
+                cell_id = entry.get("cell_id") or entry  # accept plain string too
+                if not isinstance(cell_id, str):
+                    raise ValueError(f"Each cell entry must have a cell_id string, got {entry!r}")
+                source_hash = entry.get("source_hash") if isinstance(entry, dict) else None
+                if source_hash is None:
+                    raise ValueError(f"source_hash is required for cell {cell_id!r}")
+                ycell = self._find_kernel_cell(ydoc, cell_id)
+                current_source = str(ycell.get("source", ""))
+                if _source_hash(current_source) != source_hash:
+                    raise SourceMismatchError(cell_id)
+                items.append((cell_id, ycell))
 
-        # All checks passed — mark running and enqueue atomically.
-        for cell_id, ycell in items:
-            if clear_outputs:
-                del ycell["outputs"][:]
-            ycell["execution_state"] = "running"
-            await self._execution_queue.put(_ExecutionItem(
-                cell_id=cell_id,
-                ycell=ycell,
-                file_id=file_id,
-                clear_outputs=clear_outputs,
-            ))
+            # All checks passed — mark running and enqueue atomically.
+            for cell_id, ycell in items:
+                if clear_outputs:
+                    del ycell["outputs"][:]
+                ycell["execution_state"] = "running"
+                await self._execution_queue.put(_ExecutionItem(
+                    cell_id=cell_id,
+                    ycell=ycell,
+                    file_id=file_id,
+                    clear_outputs=clear_outputs,
+                ))
+        finally:
+            # Always advance the client's sequence, even on error: the sequence
+            # slot is "consumed" by having entered execute_cells. If we didn't
+            # advance on error, successive requests would wait forever for a
+            # sequence the server has decided to skip.
+            if acquired_seq:
+                await self._advance_seq(client_id)  # type: ignore[arg-type]
 
-        # Signal that the whole batch has been enqueued.
-        if request_id is not None:
-            existing = self._enqueued_events.get(request_id)
-            if existing is not None:
-                existing.set()
-            else:
-                done = asyncio.Event()
-                done.set()
-                self._enqueued_events[request_id] = done
+    async def _wait_for_seq_turn(self, client_id: str, sequence: int) -> None:
+        """Block until it is this ``(client_id, sequence)``'s turn to enqueue.
+
+        The wait only bounds *ordering* of concurrent POSTs — not execution — so
+        it should complete on the order of a network round-trip. If a
+        predecessor request is genuinely lost (client crash, network drop) the
+        waiter would otherwise block forever; we cap it and raise
+        ``SessionResetError`` on expiry. The frontend responds to the resulting
+        409 by clearing its counter and retrying with ``sequence=0``, which
+        drains any peers still stuck behind the same lost predecessor.
+
+        Signals a session reset if ``sequence == 0`` when the server already
+        holds higher state for this client. Raises ``SessionResetError`` if a
+        reset (or kernel disconnect) happens while waiting.
+        """
+        async with self._seq_cv:
+            self._seq_generation.setdefault(client_id, 0)
+            current = self._next_seq.get(client_id, 0)
+
+            # Session reset: browser sent sequence=0 while we're past it.
+            if sequence == 0 and current > 0:
+                self._next_seq[client_id] = 0
+                self._seq_generation[client_id] += 1
+                self._seq_cv.notify_all()
+                return
+
+            if sequence < current:
+                raise SequenceOutOfRangeError(
+                    f"sequence {sequence} is below expected {current} "
+                    f"for client_id {client_id!r}"
+                )
+
+            gen_at_start = self._seq_generation[client_id]
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + self._seq_wait_timeout()
+            while self._next_seq.get(client_id, 0) < sequence:
+                remaining = deadline - loop.time()
+                timed_out = remaining <= 0
+                if not timed_out:
+                    try:
+                        await asyncio.wait_for(self._seq_cv.wait(), timeout=remaining)
+                    except asyncio.TimeoutError:
+                        timed_out = True
+                if timed_out:
+                    # Bump generation + wake every peer waiting on this client_id
+                    # before raising, so peers stuck behind the same lost
+                    # predecessor don't each eat a full timeout in serial.
+                    self._seq_generation[client_id] += 1
+                    self._seq_cv.notify_all()
+                    raise SessionResetError(
+                        f"client_id {client_id!r} timed out waiting for "
+                        f"sequence {sequence} (predecessor never arrived)"
+                    )
+                if self._seq_generation.get(client_id, 0) != gen_at_start:
+                    raise SessionResetError(
+                        f"client_id {client_id!r} session was reset "
+                        f"while waiting for sequence {sequence}"
+                    )
+
+    async def _advance_seq(self, client_id: str) -> None:
+        """Bump ``_next_seq[client_id]`` and wake any waiters."""
+        async with self._seq_cv:
+            self._next_seq[client_id] = self._next_seq.get(client_id, 0) + 1
+            self._seq_cv.notify_all()
+
+    def _seq_wait_timeout(self) -> float:
+        """Max time a waiter blocks for its predecessor's POST to arrive.
+
+        Reads ``kernel_info_timeout`` off the multi_kernel_manager when
+        available (jupyter_server's "how long may a kernel be unresponsive"
+        knob); falls back to 60s in test / stub environments.
+        """
+        km = self._kernel_manager
+        mkm = getattr(km, "parent", None) if km is not None else None
+        return float(getattr(mkm, "kernel_info_timeout", 60.0))
 
     async def execute_cell(
         self,
@@ -468,14 +580,16 @@ class YNotebookRoom(YRoom):
         source_hash: str,
         clear_outputs: bool = False,
         request_id: Optional[str] = None,
-        previous_request_id: Optional[str] = None,
+        client_id: Optional[str] = None,
+        sequence: Optional[int] = None,
     ) -> None:
         """Convenience wrapper: enqueue a single cell via execute_cells()."""
         await self.execute_cells(
             [{"cell_id": cell_id, "source_hash": source_hash}],
             clear_outputs=clear_outputs,
             request_id=request_id,
-            previous_request_id=previous_request_id,
+            client_id=client_id,
+            sequence=sequence,
         )
 
     def _find_kernel_cell(self, ydoc, cell_id: str):

--- a/jupyter_server_documents/tests/test_execute_ordering.py
+++ b/jupyter_server_documents/tests/test_execute_ordering.py
@@ -1,22 +1,22 @@
 """
-Tests for YNotebookRoom.execute_cell() — source hash verification and
-request ordering.
+Tests for YNotebookRoom.execute_cells() — source hash verification and
+sequence-based ordering.
 
 The source_hash feature prevents a cell from being executed with code the
 requesting user never saw (because a collaborator edited it in between).
 
-The request_id / previous_request_id chaining guarantees that rapid
-single-cell execute calls arrive at the queue in the same order the user
-pressed Run, regardless of network jitter.
+Sequence-based ordering guarantees rapid execute calls arrive at the
+queue in the order the user pressed Run, regardless of network jitter.
 """
 import asyncio
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from jupyter_server_documents.rooms.ynotebook_room import (
     YNotebookRoom,
+    SequenceOutOfRangeError,
+    SessionResetError,
     SourceMismatchError,
-    PredecessorTimeoutError,
     _source_hash,
 )
 
@@ -34,7 +34,10 @@ def make_room():
     room._execution_queue = asyncio.Queue()
     room._execution_worker_task = MagicMock(done=MagicMock(return_value=False))
     room.output_processor = None
-    room._enqueued_events = {}
+    room._reattach_tasks = []
+    room._next_seq = {}
+    room._seq_generation = {}
+    room._seq_cv = asyncio.Condition()
     return room
 
 
@@ -63,7 +66,6 @@ class TestSourceHashVerification:
 
     @pytest.mark.asyncio
     async def test_matching_hash_allows_execution(self):
-        """Correct hash passes through and the cell is enqueued."""
         room = make_room()
         source = "x = 1"
         ydoc, cell = make_ydoc(source)
@@ -76,22 +78,19 @@ class TestSourceHashVerification:
 
     @pytest.mark.asyncio
     async def test_mismatched_hash_raises_source_mismatch_error(self):
-        """Stale hash raises SourceMismatchError before the cell is touched."""
         room = make_room()
-        ydoc, cell = make_ydoc("x = 2")  # server has this
+        ydoc, cell = make_ydoc("x = 2")
         room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
 
         with pytest.raises(SourceMismatchError) as exc_info:
             await room.execute_cell("cell-1", source_hash=_source_hash("x = 1"))
 
         assert exc_info.value.cell_id == "cell-1"
-        # Cell must not have been touched
         assert room._execution_queue.empty()
         assert cell.get("execution_state") is None
 
     @pytest.mark.asyncio
     async def test_missing_hash_raises_value_error(self):
-        """Omitting source_hash raises ValueError (it is now required)."""
         room = make_room()
         ydoc, _ = make_ydoc("any source")
         room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
@@ -101,7 +100,6 @@ class TestSourceHashVerification:
 
     @pytest.mark.asyncio
     async def test_empty_source_hash_matches_empty_cell(self):
-        """A cell with no source and hash of '' matches correctly."""
         room = make_room()
         ydoc, _ = make_ydoc("")
         room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
@@ -110,141 +108,313 @@ class TestSourceHashVerification:
 
         assert not room._execution_queue.empty()
 
-    @pytest.mark.asyncio
-    async def test_source_mismatch_error_carries_cell_id(self):
-        """SourceMismatchError exposes the cell_id for the 409 response."""
-        room = make_room()
-        ydoc, _ = make_ydoc("server source", cell_id="my-cell-99")
-        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
 
-        with pytest.raises(SourceMismatchError) as exc_info:
-            await room.execute_cell("my-cell-99", source_hash="999999999")
+# ── sequence-based ordering ───────────────────────────────────────────────────
 
-        assert exc_info.value.cell_id == "my-cell-99"
-
-
-# ── request ordering ──────────────────────────────────────────────────────────
-
-class TestRequestOrdering:
-    """execute_cell guarantees FIFO enqueue order via request_id chaining."""
+class TestSequenceOrdering:
+    """execute_cells enqueues in strict sequence order per client_id."""
 
     @pytest.mark.asyncio
-    async def test_request_id_is_stored_after_enqueue(self):
-        """After enqueue, request_id is recorded as a set Event."""
+    async def test_in_order_arrivals_advance_next_seq(self):
+        """Three sequential arrivals bump next_seq to 3."""
         room = make_room()
         ydoc, _ = make_ydoc("x = 1")
         room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
 
-        await room.execute_cell("cell-1", source_hash=_source_hash("x = 1"), request_id="req-A")
+        for seq in range(3):
+            await room.execute_cell(
+                "cell-1",
+                source_hash=_source_hash("x = 1"),
+                client_id="tab-A",
+                sequence=seq,
+            )
 
-        assert "req-A" in room._enqueued_events
-        assert room._enqueued_events["req-A"].is_set()
+        assert room._next_seq["tab-A"] == 3
+        assert room._execution_queue.qsize() == 3
 
     @pytest.mark.asyncio
-    async def test_successor_waits_for_predecessor_event(self):
-        """A request with previous_request_id waits until that event is set."""
+    async def test_out_of_order_buffered_until_predecessor_arrives(self):
+        """seq=1 arrives before seq=0; waits, then processes after seq=0."""
         room = make_room()
         ydoc, _ = make_ydoc("x = 1")
         room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
 
-        # Pre-register a predecessor event that is NOT yet set.
-        predecessor_event = asyncio.Event()
-        room._enqueued_events["req-A"] = predecessor_event
-
-        # Start the successor — it should block until we set the event.
-        task = asyncio.create_task(
-            room.execute_cell("cell-1", source_hash=_source_hash("x = 1"), request_id="req-B", previous_request_id="req-A")
-        )
-        await asyncio.sleep(0)  # let the coroutine start
-        assert room._execution_queue.empty(), "should still be waiting"
-
-        # Release the predecessor.
-        predecessor_event.set()
-        await task
-
-        assert not room._execution_queue.empty(), "should now be enqueued"
-
-    @pytest.mark.asyncio
-    async def test_unknown_predecessor_times_out(self):
-        """If previous_request_id never arrives, the request times out.
-
-        B arrived before A but A never shows up (e.g. A's HTTP request was
-        dropped). B must not block forever — it times out with
-        PredecessorTimeoutError.
-        """
-        room = make_room()
-        ydoc, _ = make_ydoc("x = 1")
-        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
-
-        # No entry for "req-A-dropped" — simulates A being lost in transit.
-        with patch("jupyter_server_documents.rooms.ynotebook_room._PREDECESSOR_TIMEOUT", 0.05):
-            with pytest.raises(PredecessorTimeoutError):
-                await room.execute_cell(
-                    "cell-1",
-                    source_hash=_source_hash("x = 1"),
-                    request_id="req-B",
-                    previous_request_id="req-A-dropped",
-                )
-
-        assert room._execution_queue.empty()
-
-    @pytest.mark.asyncio
-    async def test_predecessor_timeout_raises(self):
-        """If the predecessor never sets its event, PredecessorTimeoutError is raised."""
-        room = make_room()
-        ydoc, _ = make_ydoc("x = 1")
-        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
-
-        # Register a predecessor that will never be set.
-        room._enqueued_events["req-stuck"] = asyncio.Event()
-
-        # Patch the timeout to a tiny value so the test runs fast.
-        with patch("jupyter_server_documents.rooms.ynotebook_room._PREDECESSOR_TIMEOUT", 0.05):
-            with pytest.raises(PredecessorTimeoutError):
-                await room.execute_cell("cell-1", source_hash=_source_hash("x = 1"), previous_request_id="req-stuck")
-
-        assert room._execution_queue.empty(), "cell must not have been enqueued"
-
-    @pytest.mark.asyncio
-    async def test_chained_requests_enqueued_in_order(self):
-        """B arrives before A but still enqueues after A (true out-of-order fix)."""
-        room = make_room()
-        cell_a = {"id": "cell-a", "cell_type": "code", "source": "a = 1", "outputs": []}
-        cell_b = {"id": "cell-b", "cell_type": "code", "source": "b = 2", "outputs": []}
-
-        call_count = 0
-        async def get_ydoc():
-            nonlocal call_count
-            call_count += 1
-            ydoc = MagicMock()
-            ydoc.ycells = [cell_a] if call_count == 1 else [cell_b]
-            return ydoc
-
-        room.get_jupyter_ydoc = get_ydoc
-
-        # B arrives first — creates an unset event for "req-A" and waits.
+        # seq=1 arrives first — should block waiting for seq=0.
         task_b = asyncio.create_task(
-            room.execute_cell("cell-b", source_hash=_source_hash("b = 2"), request_id="req-B", previous_request_id="req-A")
+            room.execute_cell(
+                "cell-1",
+                source_hash=_source_hash("x = 1"),
+                client_id="tab-A",
+                sequence=1,
+            )
         )
-        await asyncio.sleep(0)  # let B start and register its wait
-        assert room._execution_queue.empty(), "B should be blocked waiting for A"
+        # Give the coroutine a chance to hit the wait.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert room._execution_queue.empty(), "seq=1 must be blocked waiting for seq=0"
 
-        # A arrives and enqueues — sets the event B is waiting on.
-        await room.execute_cell("cell-a", source_hash=_source_hash("a = 1"), request_id="req-A")
-        await task_b  # B should now complete
+        # seq=0 arrives — should enqueue, then unblock seq=1 which also enqueues.
+        await room.execute_cell(
+            "cell-1",
+            source_hash=_source_hash("x = 1"),
+            client_id="tab-A",
+            sequence=0,
+        )
+        await task_b
 
-        a_item = room._execution_queue.get_nowait()
-        b_item = room._execution_queue.get_nowait()
-        assert a_item.cell_id == "cell-a"
-        assert b_item.cell_id == "cell-b"
+        assert room._execution_queue.qsize() == 2
+        assert room._next_seq["tab-A"] == 2
 
     @pytest.mark.asyncio
-    async def test_enqueued_events_cleared_on_disconnect(self):
-        """disconnect_kernel() clears _enqueued_events to avoid stale state."""
+    async def test_sequence_below_next_seq_raises(self):
+        """A late/duplicate sequence below next_seq is rejected."""
         room = make_room()
-        room._enqueued_events["req-old-1"] = asyncio.Event()
-        room._enqueued_events["req-old-1"].set()
-        room._enqueued_events["req-old-2"] = asyncio.Event()
+        ydoc, _ = make_ydoc("x = 1")
+        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
+
+        # Advance to seq=1 (next_seq=2).
+        await room.execute_cell("cell-1", source_hash=_source_hash("x = 1"), client_id="tab-A", sequence=0)
+        await room.execute_cell("cell-1", source_hash=_source_hash("x = 1"), client_id="tab-A", sequence=1)
+
+        with pytest.raises(SequenceOutOfRangeError):
+            await room.execute_cell(
+                "cell-1",
+                source_hash=_source_hash("x = 1"),
+                client_id="tab-A",
+                sequence=1,   # already processed
+            )
+
+    @pytest.mark.asyncio
+    async def test_sequence_zero_after_high_seq_resets_state(self):
+        """seq=0 after next_seq > 0 clears state and starts over."""
+        room = make_room()
+        ydoc, _ = make_ydoc("x = 1")
+        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
+
+        for seq in range(3):
+            await room.execute_cell(
+                "cell-1",
+                source_hash=_source_hash("x = 1"),
+                client_id="tab-A",
+                sequence=seq,
+            )
+        assert room._next_seq["tab-A"] == 3
+
+        # Browser resets — sends seq=0.
+        await room.execute_cell(
+            "cell-1",
+            source_hash=_source_hash("x = 1"),
+            client_id="tab-A",
+            sequence=0,
+        )
+        # After reset + this request, next_seq is 1 (0 processed, advanced to 1).
+        assert room._next_seq["tab-A"] == 1
+
+    @pytest.mark.asyncio
+    async def test_session_reset_wakes_pending_waiter(self):
+        """A pending seq=5 waiter is abandoned when a seq=0 reset arrives."""
+        room = make_room()
+        ydoc, _ = make_ydoc("x = 1")
+        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
+
+        # Advance to next_seq=1 first (so the reset actually resets something).
+        await room.execute_cell("cell-1", source_hash=_source_hash("x = 1"), client_id="tab-A", sequence=0)
+
+        # seq=5 arrives, blocks waiting for seq=1..4.
+        waiter = asyncio.create_task(
+            room.execute_cell(
+                "cell-1",
+                source_hash=_source_hash("x = 1"),
+                client_id="tab-A",
+                sequence=5,
+            )
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert not waiter.done()
+
+        # Reset comes in — the waiter should raise SessionResetError.
+        await room.execute_cell(
+            "cell-1",
+            source_hash=_source_hash("x = 1"),
+            client_id="tab-A",
+            sequence=0,
+        )
+
+        with pytest.raises(SessionResetError):
+            await waiter
+
+    @pytest.mark.asyncio
+    async def test_lost_predecessor_times_out(self, monkeypatch):
+        """A waiter whose predecessor request never arrives is abandoned
+        after ``kernel_info_timeout`` so peers stuck behind it recover."""
+        room = make_room()
+        ydoc, _ = make_ydoc("x = 1")
+        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
+
+        # Force a short timeout so the test doesn't wait 60s.
+        monkeypatch.setattr(room, "_seq_wait_timeout", lambda: 0.05)
+
+        # Send seq=3 without ever sending seq=0..2.
+        with pytest.raises(SessionResetError, match="timed out"):
+            await room.execute_cell(
+                "cell-1",
+                source_hash=_source_hash("x = 1"),
+                client_id="tab-A",
+                sequence=3,
+            )
+
+    @pytest.mark.asyncio
+    async def test_advances_even_on_source_mismatch(self):
+        """A failed request still advances the sequence — the slot is used."""
+        room = make_room()
+        ydoc, _ = make_ydoc("x = 1")
+        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
+
+        with pytest.raises(SourceMismatchError):
+            await room.execute_cell(
+                "cell-1",
+                source_hash="does-not-match",
+                client_id="tab-A",
+                sequence=0,
+            )
+
+        # next_seq must have advanced so subsequent requests aren't stuck.
+        assert room._next_seq["tab-A"] == 1
+
+        # Next request with seq=1 proceeds normally.
+        await room.execute_cell(
+            "cell-1",
+            source_hash=_source_hash("x = 1"),
+            client_id="tab-A",
+            sequence=1,
+        )
+        assert not room._execution_queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_independent_clients_dont_block_each_other(self):
+        """tab-A's out-of-order queue doesn't block tab-B."""
+        room = make_room()
+        ydoc, _ = make_ydoc("x = 1")
+        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
+
+        # tab-A seq=1 arrives first — blocks.
+        waiter_a = asyncio.create_task(
+            room.execute_cell(
+                "cell-1",
+                source_hash=_source_hash("x = 1"),
+                client_id="tab-A",
+                sequence=1,
+            )
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert not waiter_a.done()
+
+        # tab-B seq=0 must run to completion independently.
+        await room.execute_cell(
+            "cell-1",
+            source_hash=_source_hash("x = 1"),
+            client_id="tab-B",
+            sequence=0,
+        )
+        assert room._next_seq["tab-B"] == 1
+
+        # Unblock tab-A.
+        await room.execute_cell(
+            "cell-1",
+            source_hash=_source_hash("x = 1"),
+            client_id="tab-A",
+            sequence=0,
+        )
+        await waiter_a
+        assert room._next_seq["tab-A"] == 2
+
+    @pytest.mark.asyncio
+    async def test_sequence_state_cleared_on_disconnect(self):
+        """disconnect_kernel() clears next_seq and abandons pending waiters."""
+        room = make_room()
+        ydoc, _ = make_ydoc("x = 1")
+        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
+
+        await room.execute_cell("cell-1", source_hash=_source_hash("x = 1"), client_id="tab-A", sequence=0)
+
+        waiter = asyncio.create_task(
+            room.execute_cell(
+                "cell-1",
+                source_hash=_source_hash("x = 1"),
+                client_id="tab-A",
+                sequence=5,
+            )
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert not waiter.done()
+
+        # Prep for disconnect_kernel — pretend the worker task is already done.
+        room._execution_worker_task = MagicMock()
+        room._execution_worker_task.done.return_value = True
+        room._kernel_manager = MagicMock(
+            remove_restart_callback=MagicMock(side_effect=Exception("not registered"))
+        )
+
+        await room.disconnect_kernel()
+
+        assert room._next_seq == {}
+        with pytest.raises(SessionResetError):
+            await waiter
+
+class TestSequencePreservedAcrossRestart:
+    """Kernel restart-in-place preserves per-client sequence counters.
+
+    The browser's per-``docKey`` counter isn't reset on restart (same
+    ``kernel_id``), so the server's ``_next_seq`` must survive too —
+    otherwise the next request (with sequence N > 0) waits forever for
+    predecessors that will never arrive.
+    """
+
+    @pytest.mark.asyncio
+    async def test_disconnect_kernel_reset_false_preserves_next_seq(self):
+        room = make_room()
+        ydoc, _ = make_ydoc("x = 1")
+        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
+
+        # Advance next_seq to 3 by running three cells.
+        for seq in range(3):
+            await room.execute_cell(
+                "cell-1",
+                source_hash=_source_hash("x = 1"),
+                client_id="tab-A",
+                sequence=seq,
+            )
+        assert room._next_seq["tab-A"] == 3
+
+        # Prep for disconnect_kernel — pretend worker is already done.
+        room._execution_worker_task = MagicMock()
+        room._execution_worker_task.done.return_value = True
+        room._kernel_manager = MagicMock(
+            remove_restart_callback=MagicMock(side_effect=Exception("not registered"))
+        )
+
+        await room.disconnect_kernel(reset_sequences=False)
+
+        # Next_seq preserved. Next request with sequence=3 proceeds normally.
+        assert room._next_seq["tab-A"] == 3
+
+    @pytest.mark.asyncio
+    async def test_default_disconnect_kernel_still_resets(self):
+        """Default reset_sequences=True still clears state (existing behaviour)."""
+        room = make_room()
+        ydoc, _ = make_ydoc("x = 1")
+        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
+
+        await room.execute_cell(
+            "cell-1",
+            source_hash=_source_hash("x = 1"),
+            client_id="tab-A",
+            sequence=0,
+        )
+        assert room._next_seq["tab-A"] == 1
 
         room._execution_worker_task = MagicMock()
         room._execution_worker_task.done.return_value = True
@@ -254,34 +424,4 @@ class TestRequestOrdering:
 
         await room.disconnect_kernel()
 
-        assert room._enqueued_events == {}
-
-    @pytest.mark.asyncio
-    async def test_predecessor_entry_deleted_after_consumption(self):
-        """Predecessor event is removed from _enqueued_events once consumed."""
-        room = make_room()
-        ydoc, _ = make_ydoc("x = 1")
-        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
-
-        # Enqueue A, then B chained after A.
-        await room.execute_cell("cell-1", source_hash=_source_hash("x = 1"), request_id="req-A")
-        await room.execute_cell("cell-1", source_hash=_source_hash("x = 1"), request_id="req-B", previous_request_id="req-A")
-
-        # A's entry should be gone (consumed by B); B's entry is the tail.
-        assert "req-A" not in room._enqueued_events
-        assert "req-B" in room._enqueued_events
-
-    @pytest.mark.asyncio
-    async def test_timed_out_predecessor_entry_deleted(self):
-        """Timed-out predecessor event is removed, not left as an orphan."""
-        room = make_room()
-        ydoc, _ = make_ydoc("x = 1")
-        room.get_jupyter_ydoc = AsyncMock(return_value=ydoc)
-
-        room._enqueued_events["req-stuck"] = asyncio.Event()  # never set
-
-        with patch("jupyter_server_documents.rooms.ynotebook_room._PREDECESSOR_TIMEOUT", 0.05):
-            with pytest.raises(PredecessorTimeoutError):
-                await room.execute_cell("cell-1", source_hash=_source_hash("x = 1"), previous_request_id="req-stuck")
-
-        assert "req-stuck" not in room._enqueued_events
+        assert room._next_seq == {}

--- a/jupyter_server_documents/tests/test_yroom_kernel.py
+++ b/jupyter_server_documents/tests/test_yroom_kernel.py
@@ -34,7 +34,9 @@ def make_yroom():
     room._execution_queue = None
     room._execution_worker_task = None
     room.output_processor = None
-    room._enqueued_events = {}
+    room._next_seq = {}
+    room._seq_generation = {}
+    room._seq_cv = asyncio.Condition()
     return room
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,9 +71,12 @@ export const serverCellExecutorPlugin: JupyterFrontEndPlugin<INotebookCellExecut
       }
 
       const serverSettings = app.serviceManager.serverSettings;
-      // Track the last request_id per document so successive runCell calls
-      // can chain previous_request_id without touching any notebook internals.
-      const lastRequestIdByDoc = new Map<string, string>();
+      // Sequence-based ordering: per (document, client, kernel) monotonic
+      // counter. The server enqueues in sequence order; out-of-order
+      // arrivals are buffered until their predecessors show up. Reset to
+      // 0 signals a session reset to the server.
+      const nextSeqByDoc = new Map<string, number>();
+
       return {
         async runCell({
           cell,
@@ -108,7 +111,20 @@ export const serverCellExecutorPlugin: JupyterFrontEndPlugin<INotebookCellExecut
             return true;
           }
 
+          // sessionContext.hasNoKernel can flip to false the moment a
+          // Kernel object exists, before the server has assigned it an
+          // id. Await ``sessionContext.ready`` (resolves once the
+          // session + kernel are fully connected) and re-check the
+          // kernel id — otherwise we POST to
+          // ``/api/kernels/undefined/execute`` and the server rejects
+          // with "YNotebookRoom is not connected to a kernel".
+          await sessionContext.ready;
           const kernelId = sessionContext?.session?.kernel?.id;
+          if (!kernelId) {
+            onCellExecuted({ cell, success: false });
+            return false;
+          }
+
           const apiURL = URLExt.join(
             serverSettings.baseUrl,
             `api/kernels/${kernelId}/execute`
@@ -138,15 +154,17 @@ export const serverCellExecutorPlugin: JupyterFrontEndPlugin<INotebookCellExecut
             notebook.sharedModel.awareness?.clientID ?? ''
           );
 
-          // Generate a unique ID for this request and chain it to the
-          // previous one so the server can enforce FIFO order even when
-          // network jitter causes requests to arrive out of sequence.
-          // The chain is keyed per document+client so that two users running
-          // cells simultaneously don't block each other.
-          const docKey = `${documentId ?? path}:${clientId}`;
+          // Generate a unique ID for this request (opaque, for tracing)
+          // and attach a monotonic sequence number so the server enqueues
+          // requests in strict order per (document, client, kernel)
+          // regardless of arrival timing. The counter is keyed by
+          // kernel_id as well so that when the kernel changes, the
+          // counter naturally resets to 0 for the new kernel — matching
+          // the server's per-disconnect _next_seq clear.
+          const docKey = `${documentId ?? path}:${clientId}:${kernelId}`;
           const requestId = crypto.randomUUID();
-          const previousRequestId = lastRequestIdByDoc.get(docKey);
-          lastRequestIdByDoc.set(docKey, requestId);
+          const sequence = nextSeqByDoc.get(docKey) ?? 0;
+          nextSeqByDoc.set(docKey, sequence + 1);
 
           if (!documentId) {
             // document_id not yet in shared model state — fall back to path.
@@ -165,19 +183,34 @@ export const serverCellExecutorPlugin: JupyterFrontEndPlugin<INotebookCellExecut
                   cells: [{ cell_id: cellId, source_hash: sourceHash }],
                   client_id: clientId || undefined,
                   request_id: requestId,
-                  ...(previousRequestId
-                    ? { previous_request_id: previousRequestId }
-                    : {})
+                  sequence
                 })
               },
               serverSettings
             );
             if (response.status === 409) {
-              // Source mismatch — another user edited the cell after this user
-              // pressed Run. Show a visible warning so the user knows to re-run.
-              // Clear the ordering chain: this request was never enqueued on the
-              // server so the next run must not reference it as a predecessor.
-              lastRequestIdByDoc.delete(docKey);
+              // Two distinct 409 shapes:
+              //   { error: "source_mismatch", cell_id: ... } — the source
+              //     changed under us; the server advanced the sequence
+              //     slot regardless, so our counter is still in sync.
+              //   { error: "session_reset" } — the server rewound state
+              //     (kernel disconnect or an explicit seq=0 from us);
+              //     reset our counter so the next request starts fresh.
+              let body: { error?: string } = {};
+              try {
+                body = await response.json();
+              } catch {
+                // fall through with empty body
+              }
+              if (body.error === 'session_reset') {
+                nextSeqByDoc.delete(docKey);
+                Notification.warning(
+                  'Cell not executed: the kernel changed while the request was in flight. Please re-run the cell.',
+                  { autoClose: 5000 }
+                );
+                onCellExecuted({ cell, success: false });
+                return false;
+              }
               Notification.warning(
                 'Cell not executed: the cell source changed while the request was in flight. Please re-run the cell.',
                 { autoClose: 5000 }
@@ -186,9 +219,10 @@ export const serverCellExecutorPlugin: JupyterFrontEndPlugin<INotebookCellExecut
               return false;
             }
             if (!response.ok) {
-              // Any other failure (408, 500, etc.) also breaks the chain —
-              // the request was never successfully enqueued.
-              lastRequestIdByDoc.delete(docKey);
+              // 4xx/5xx other than 409 — conservatively reset the counter
+              // so we don't wedge on a sequence the server may not have
+              // observed.
+              nextSeqByDoc.delete(docKey);
             }
             onCellExecuted({ cell, success: response.ok });
             return response.ok;


### PR DESCRIPTION
Cells execute server-side via `POST /api/kernels/{kernel_id}/execute`. A "Run All" (or several quick runs) fires multiple of these POSTs, and they can reach the server out of order — HTTP/2 streams and independent HTTP/1.1 connections make no ordering promise — so the server needs to re-establish the user's intended order. Today it does that with a `previous_request_id` predecessor chain; this replaces that with a per-client monotonic sequence, which gives a simpler client contract and, because it's an absolute position rather than a relative link, lets the server detect gaps/duplicates/rewinds and recover deterministically.

### REST request model

```jsonc
POST /api/kernels/{kernel_id}/execute
{
  "document_id": "string",     // required — room / document id
  "cells": [                   // required — run atomically, in order
    { "cell_id": "string", "source_hash": "string" }
  ],

  // ordering (client_id is required when sequence is present)
  "client_id": "string",       // identifies the browser tab; scopes `sequence`
  "sequence": 0,               // monotonic counter per client_id, starts at 0
  "request_id": "string"       // opaque UUID for logging / tracing
}
```

What changed in the ordering fields:

```diff
   "client_id": "string",
-  "request_id": "string",
-  "previous_request_id": "string"  // wait for this request to be enqueued first
+  "sequence": 0,                   // monotonic counter per client_id, starts at 0
+  "request_id": "string"           // opaque UUID for logging / tracing
```

The server enqueues per `client_id` in `sequence` order, buffering out-of-order arrivals until their predecessors show up. Because `sequence` is an absolute position, the server can reject a rewind (`sequence` below what it has already seen) and treat `sequence == 0`, when it is already ahead, as a session reset (new tab, kernel swap, explicit reset): state is cleared and pending waiters are abandoned with `SessionResetError` (surfaced as `409`, which the frontend retries from `sequence=0`). A predecessor that never arrives is still capped by a timeout — same safety net as before — but recovery is the deterministic reset rather than proceeding out of order. An in-place kernel restart keeps the same kernel id, so the client's counter stays valid — `disconnect_kernel(reset_sequences=False)` preserves it across that reconnect.

First of three layered PRs; this one is just the ordering change (the execute-loop rewrite and the session-manager simplification follow on top).